### PR TITLE
Fixed cache issue while accept/reject friendship request

### DIFF
--- a/friendship/models.py
+++ b/friendship/models.py
@@ -90,6 +90,7 @@ class FriendshipRequest(models.Model):
             )
 
         self.delete()
+        bust_cache('requests', self.to_user.pk)
         return True
 
     def reject(self):
@@ -97,17 +98,20 @@ class FriendshipRequest(models.Model):
         self.rejected = datetime.datetime.now()
         friendship_request_rejected.send(sender=self)
         self.save()
+        bust_cache('requests', self.to_user.pk)
 
     def cancel(self):
         """ cancel this friendship request """
         self.delete()
         friendship_request_canceled.send(sender=self)
+        bust_cache('requests', self.to_user.pk)
         return True
 
     def mark_viewed(self):
         self.viewed = datetime.datetime.now()
         friendship_request_viewed.send(sender=self)
         self.save()
+        bust_cache('requests', self.to_user.pk)
         return True
 
 


### PR DESCRIPTION
There was a cache issue in the model `FriendshipRequest`.
Action methods like `accept`, `reject` did not reseted a cache. This why method `Friend.objects.unread_requests` were returning wrong results.
