### PR TITLE
Django 1.7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ env:
   - DJANGO="Django==1.5"
   - DJANGO="Django==1.5.7"
   - DJANGO="Django==1.6.4"
-  - DJANGO="https://www.djangoproject.com/m/releases/1.7/Django-1.7b1.tar.gz#egg=django"
+  - DJANGO="Django==1.7"
 
 matrix:
   exclude:
     # Python 2.6 support has been dropped in Django 1.7
     - python: "2.6"
-      env: DJANGO="https://www.djangoproject.com/m/releases/1.7/Django-1.7b1.tar.gz#egg=django"
+      env: DJANGO="Django==1.7"

--- a/friendship/tests/runtests.py
+++ b/friendship/tests/runtests.py
@@ -2,6 +2,7 @@
 import sys
 
 from django.conf import settings
+from django.conf import global_settings
 
 settings.configure(
     DATABASES = {
@@ -16,6 +17,9 @@ settings.configure(
     ],
     ROOT_URLCONF='friendship.urls',
     TEST_RUNNER = 'django_coverage.coverage_runner.CoverageRunner',
+    MIDDLEWARE_CLASSES = global_settings.MIDDLEWARE_CLASSES + (
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',)
 )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
 
 [django17]
 deps =
-    https://www.djangoproject.com/m/releases/1.7/Django-1.7b1.tar.gz#egg=django
+    https://www.djangoproject.com/m/releases/1.7/Django-1.7.tar.gz#egg=django
     coverage==3.7.1
     django-coverage==1.2.4
 


### PR DESCRIPTION
[Contrib middleware removed from default MIDDLEWARE_CLASSES](http://django.readthedocs.org/en/latest/releases/1.7.html#contrib-middleware-removed-from-default-middleware-classes)
