### PR TITLE
removed {% import url from future %} for django1.9

### DIFF
--- a/friendship/templates/friendship/friend/request.html
+++ b/friendship/templates/friendship/friend/request.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <div>{{ friendship_request.from_user }} wants to be friends with {{ friendship_request.to_user }}</div>
 
 <form method="post" action="{% url 'friendship_accept' friendship_request.pk %}">

--- a/friendship/templates/friendship/friend/requests_list.html
+++ b/friendship/templates/friendship/friend/requests_list.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <ul>
 {% for friendship_request in requests %}
     <li>{{ friendship_request.from_user }} to {{ friendship_request.to_user }} <a href="{% url 'friendship_requests_detail' friendship_request.id %}">view</a></li>

--- a/friendship/templates/friendship/header.html
+++ b/friendship/templates/friendship/header.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <div id="link_nav">
 hello {{ user.username }} <a href="{% url 'friendship_requests' %}">friendship requests</a>
 </div>

--- a/friendship/templates/friendship/user_actions.html
+++ b/friendship/templates/friendship/user_actions.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <ul>
 {% for list_user in users %}
     <li>

--- a/friendship/tests/templates/friendship/friend/request.html
+++ b/friendship/tests/templates/friendship/friend/request.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <div>{{ friendship_request.from_user }} wants to be friends with {{ friendship_request.to_user }}</div>
 
 <form method="post" action="{% url 'friendship_accept' friendship_request.pk %}">

--- a/friendship/tests/templates/friendship/friend/requests_list.html
+++ b/friendship/tests/templates/friendship/friend/requests_list.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <ul>
 {% for friendship_request in requests %}
     <li>{{ friendship_request.from_user }} to {{ friendship_request.to_user }} <a href="{% url 'friendship_requests_detail' friendship_request.id %}">view</a></li>

--- a/friendship/tests/templates/friendship/header.html
+++ b/friendship/tests/templates/friendship/header.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <div id="link_nav">
 hello {{ user.username }} <a href="{% url 'friendship_requests' %}">friendship requests</a>
 </div>

--- a/friendship/tests/templates/friendship/user_actions.html
+++ b/friendship/tests/templates/friendship/user_actions.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <ul>
 {% for list_user in object_list %}
     <li>


### PR DESCRIPTION
"ssi and url template tags will be removed from the future template tag library (used during the 1.3/1.4 deprecation period)."
per https://docs.djangoproject.com/es/1.9/internals/deprecation/