### PR TITLE
Fix friend templatetags and generic views for Django 1.9.

### DIFF
--- a/friendship/templates/friendship/follow/followers_list.html
+++ b/friendship/templates/friendship/follow/followers_list.html
@@ -1,5 +1,6 @@
-{% block content %} 
+{% block content %}
 {% load friendshiptags %}
-<h1>Followers</h1> 
-{% followers user %}
-{% endblock %} 
+<h1>Followers</h1>
+{% get_by_name friendship_context_object_name as var %}
+{% followers var %}
+{% endblock %}

--- a/friendship/templates/friendship/follow/following_list.html
+++ b/friendship/templates/friendship/follow/following_list.html
@@ -1,5 +1,6 @@
-{% block content %} 
-{% load friendshiptags %} 
-<h1>Following</h1> 
-{% following user %}
-{% endblock content %}
+{% block content %}
+{% load friendshiptags %}
+<h1>Following</h1>
+{% get_by_name friendship_context_object_name as var %}
+{% following var %}
+{% endblock %}

--- a/friendship/templates/friendship/friend/user_list.html
+++ b/friendship/templates/friendship/friend/user_list.html
@@ -1,5 +1,6 @@
-{% block content %} 
+{% block content %}
 {% load friendshiptags %}
-<h1>Your Friends</h1> 
-{% friends user %}
-{% endblock %} 
+<h1>Your Friends</h1>
+{% get_by_name friendship_context_object_name as var %}
+{% friends var %}
+{% endblock %}

--- a/friendship/templatetags/friendshiptags.py
+++ b/friendship/templatetags/friendshiptags.py
@@ -5,6 +5,12 @@ from friendship.models import Friend, Follow, FriendshipRequest
 register = template.Library()
 
 
+@register.simple_tag(takes_context=True)
+def get_by_name(context, name):
+    """Tag to lookup a variable in the current context."""
+    return context[name]
+
+
 @register.inclusion_tag('friendship/templatetags/friends.html')
 def friends(user):
     """

--- a/friendship/templatetags/friendshiptags.py
+++ b/friendship/templatetags/friendshiptags.py
@@ -5,7 +5,7 @@ from friendship.models import Friend, Follow, FriendshipRequest
 register = template.Library()
 
 
-@register.simple_tag(takes_context=True)
+@register.assignment_tag(takes_context=True)
 def get_by_name(context, name):
     """Tag to lookup a variable in the current context."""
     return context[name]

--- a/friendship/views.py
+++ b/friendship/views.py
@@ -20,8 +20,10 @@ def view_friends(request, username, template_name='friendship/friend/user_list.h
     """ View the friends of a user """
     user = get_object_or_404(user_model, username=username)
     friends = Friend.objects.friends(user)
-    return render(request, template_name, {get_friendship_context_object_name(): user, 'friends': friends})
-
+    return render(request, template_name, {
+        get_friendship_context_object_name(): user,
+        'friendship_context_object_name': get_friendship_context_object_name()
+    })
 
 
 @login_required
@@ -112,7 +114,10 @@ def followers(request, username, template_name='friendship/follow/followers_list
     user = get_object_or_404(user_model, username=username)
     followers = Follow.objects.followers(user)
 
-    return render(request, template_name, {get_friendship_context_object_name(): user, 'followers': followers})
+    return render(request, template_name, {
+        get_friendship_context_object_name(): user,
+        'friendship_context_object_name': get_friendship_context_object_name()
+    })
 
 
 def following(request, username, template_name='friendship/follow/following_list.html'):
@@ -120,7 +125,10 @@ def following(request, username, template_name='friendship/follow/following_list
     user = get_object_or_404(user_model, username=username)
     following = Follow.objects.following(user)
 
-    return render(request, template_name, {get_friendship_context_object_name(): user, 'following': following})
+    return render(request, template_name, {
+        get_friendship_context_object_name(): user,
+        'friendship_context_object_name': get_friendship_context_object_name()
+    })
 
 
 @login_required


### PR DESCRIPTION
Several views are broken when tested against Django 1.9.

The problem is that a configurable friendship context object name was added at some point, but these templates were not updated.  These templates continued to use the name `user`.  In Django 1.9, the `user` variable in a template appears to be proxied to an `AnonymousUser` object, and several tests fail with the exception:
`TypeError: 'AnonymousUser' object is not iterable`.  I did not verify whether this behavior changed from 1.8 to 1.9, but I assume it did or I don't think these tests would have passed before.

This fix adds the configurable object name to each context.  This name is then used to retrieve the user object via a new template tag that looks up a variable in the current context.