### PR TITLE
Support django 2.0

### DIFF
--- a/friendship/migrations/0001_initial.py
+++ b/friendship/migrations/0001_initial.py
@@ -18,8 +18,8 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created', models.DateTimeField(default=django.utils.timezone.now)),
-                ('followee', models.ForeignKey(related_name='followers', to=settings.AUTH_USER_MODEL)),
-                ('follower', models.ForeignKey(related_name='following', to=settings.AUTH_USER_MODEL)),
+                ('followee', models.ForeignKey(related_name='followers', on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('follower', models.ForeignKey(related_name='following', on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'verbose_name': 'Following Relationship',
@@ -31,8 +31,8 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created', models.DateTimeField(default=django.utils.timezone.now)),
-                ('from_user', models.ForeignKey(related_name='_unused_friend_relation', to=settings.AUTH_USER_MODEL)),
-                ('to_user', models.ForeignKey(related_name='friends', to=settings.AUTH_USER_MODEL)),
+                ('from_user', models.ForeignKey(related_name='_unused_friend_relation', on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('to_user', models.ForeignKey(related_name='friends', on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'verbose_name': 'Friend',
@@ -47,8 +47,8 @@ class Migration(migrations.Migration):
                 ('created', models.DateTimeField(default=django.utils.timezone.now)),
                 ('rejected', models.DateTimeField(null=True, blank=True)),
                 ('viewed', models.DateTimeField(null=True, blank=True)),
-                ('from_user', models.ForeignKey(related_name='friendship_requests_sent', to=settings.AUTH_USER_MODEL)),
-                ('to_user', models.ForeignKey(related_name='friendship_requests_received', to=settings.AUTH_USER_MODEL)),
+                ('from_user', models.ForeignKey(related_name='friendship_requests_sent', on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('to_user', models.ForeignKey(related_name='friendship_requests_received', on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'verbose_name': 'Friendship Request',

--- a/friendship/models.py
+++ b/friendship/models.py
@@ -70,8 +70,8 @@ def bust_cache(type, user_pk):
 @python_2_unicode_compatible
 class FriendshipRequest(models.Model):
     """ Model to represent friendship requests """
-    from_user = models.ForeignKey(AUTH_USER_MODEL, related_name='friendship_requests_sent')
-    to_user = models.ForeignKey(AUTH_USER_MODEL, related_name='friendship_requests_received')
+    from_user = models.ForeignKey(AUTH_USER_MODEL, models.CASCADE, related_name='friendship_requests_sent')
+    to_user = models.ForeignKey(AUTH_USER_MODEL, models.CASCADE, related_name='friendship_requests_received')
 
     message = models.TextField(_('Message'), blank=True)
 
@@ -342,8 +342,8 @@ class FriendshipManager(models.Manager):
 @python_2_unicode_compatible
 class Friend(models.Model):
     """ Model to represent Friendships """
-    to_user = models.ForeignKey(AUTH_USER_MODEL, related_name='friends')
-    from_user = models.ForeignKey(AUTH_USER_MODEL, related_name='_unused_friend_relation')
+    to_user = models.ForeignKey(AUTH_USER_MODEL, models.CASCADE, related_name='friends')
+    from_user = models.ForeignKey(AUTH_USER_MODEL, models.CASCADE, related_name='_unused_friend_relation')
     created = models.DateTimeField(default=timezone.now)
 
     objects = FriendshipManager()
@@ -443,8 +443,8 @@ class FollowingManager(models.Manager):
 @python_2_unicode_compatible
 class Follow(models.Model):
     """ Model to represent Following relationships """
-    follower = models.ForeignKey(AUTH_USER_MODEL, related_name='following')
-    followee = models.ForeignKey(AUTH_USER_MODEL, related_name='followers')
+    follower = models.ForeignKey(AUTH_USER_MODEL, models.CASCADE, related_name='following')
+    followee = models.ForeignKey(AUTH_USER_MODEL, models.CASCADE, related_name='followers')
     created = models.DateTimeField(default=timezone.now)
 
     objects = FollowingManager()


### PR DESCRIPTION
On models with ForeignKey the on_delete parameter is a requirement now.
The default is models.CASCADE, so that is now being used.

The migrations are also changed because they now require it too. Only
the existing one has been modified, because otherwise django would
complain. The default on_delete is used anyway, so it shouldn't matter.

The use of `assignment_tag` has been replaced with `simple_tag` for deprecation reasons.