### PR TITLE
Django 2.0+ support

### DIFF
--- a/friendship/migrations/0001_initial.py
+++ b/friendship/migrations/0001_initial.py
@@ -18,8 +18,8 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created', models.DateTimeField(default=django.utils.timezone.now)),
-                ('followee', models.ForeignKey(related_name='followers', to=settings.AUTH_USER_MODEL)),
-                ('follower', models.ForeignKey(related_name='following', to=settings.AUTH_USER_MODEL)),
+                ('followee', models.ForeignKey(related_name='followers', on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('follower', models.ForeignKey(related_name='following', on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'verbose_name': 'Following Relationship',
@@ -31,8 +31,8 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created', models.DateTimeField(default=django.utils.timezone.now)),
-                ('from_user', models.ForeignKey(related_name='_unused_friend_relation', to=settings.AUTH_USER_MODEL)),
-                ('to_user', models.ForeignKey(related_name='friends', to=settings.AUTH_USER_MODEL)),
+                ('from_user', models.ForeignKey(related_name='_unused_friend_relation', on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('to_user', models.ForeignKey(related_name='friends', on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'verbose_name': 'Friend',
@@ -47,8 +47,8 @@ class Migration(migrations.Migration):
                 ('created', models.DateTimeField(default=django.utils.timezone.now)),
                 ('rejected', models.DateTimeField(null=True, blank=True)),
                 ('viewed', models.DateTimeField(null=True, blank=True)),
-                ('from_user', models.ForeignKey(related_name='friendship_requests_sent', to=settings.AUTH_USER_MODEL)),
-                ('to_user', models.ForeignKey(related_name='friendship_requests_received', to=settings.AUTH_USER_MODEL)),
+                ('from_user', models.ForeignKey(related_name='friendship_requests_sent', on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('to_user', models.ForeignKey(related_name='friendship_requests_received', on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'verbose_name': 'Friendship Request',

--- a/friendship/models.py
+++ b/friendship/models.py
@@ -70,8 +70,8 @@ def bust_cache(type, user_pk):
 @python_2_unicode_compatible
 class FriendshipRequest(models.Model):
     """ Model to represent friendship requests """
-    from_user = models.ForeignKey(AUTH_USER_MODEL, related_name='friendship_requests_sent')
-    to_user = models.ForeignKey(AUTH_USER_MODEL, related_name='friendship_requests_received')
+    from_user = models.ForeignKey(AUTH_USER_MODEL, models.CASCADE, related_name='friendship_requests_sent')
+    to_user = models.ForeignKey(AUTH_USER_MODEL, models.CASCADE, related_name='friendship_requests_received')
 
     message = models.TextField(_('Message'), blank=True)
 
@@ -342,8 +342,8 @@ class FriendshipManager(models.Manager):
 @python_2_unicode_compatible
 class Friend(models.Model):
     """ Model to represent Friendships """
-    to_user = models.ForeignKey(AUTH_USER_MODEL, related_name='friends')
-    from_user = models.ForeignKey(AUTH_USER_MODEL, related_name='_unused_friend_relation')
+    to_user = models.ForeignKey(AUTH_USER_MODEL, models.CASCADE, related_name='friends')
+    from_user = models.ForeignKey(AUTH_USER_MODEL, models.CASCADE, related_name='_unused_friend_relation')
     created = models.DateTimeField(default=timezone.now)
 
     objects = FriendshipManager()
@@ -443,8 +443,8 @@ class FollowingManager(models.Manager):
 @python_2_unicode_compatible
 class Follow(models.Model):
     """ Model to represent Following relationships """
-    follower = models.ForeignKey(AUTH_USER_MODEL, related_name='following')
-    followee = models.ForeignKey(AUTH_USER_MODEL, related_name='followers')
+    follower = models.ForeignKey(AUTH_USER_MODEL, models.CASCADE, related_name='following')
+    followee = models.ForeignKey(AUTH_USER_MODEL, models.CASCADE, related_name='followers')
     created = models.DateTimeField(default=timezone.now)
 
     objects = FollowingManager()

--- a/friendship/templatetags/friendshiptags.py
+++ b/friendship/templatetags/friendshiptags.py
@@ -5,7 +5,7 @@ from friendship.models import Friend, Follow, FriendshipRequest
 register = template.Library()
 
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def get_by_name(context, name):
     """Tag to lookup a variable in the current context."""
     return context[name]

--- a/friendship/tests/tests.py
+++ b/friendship/tests/tests.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 
 from friendship.exceptions import AlreadyExistsError, AlreadyFriendsError

--- a/runtests.py
+++ b/runtests.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python
 import sys
 
+import django
 from django.conf import global_settings, settings
 
+
+if django.VERSION[0:2] < (2, 0):
+    CURRENT_MIDDLEWARE = global_settings.MIDDLEWARE_CLASSES
+else:
+    CURRENT_MIDDLEWARE = global_settings.MIDDLEWARE
+
 OUR_MIDDLEWARE = []
-OUR_MIDDLEWARE.extend(global_settings.MIDDLEWARE)
+OUR_MIDDLEWARE.extend(CURRENT_MIDDLEWARE)
 OUR_MIDDLEWARE.extend([
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/runtests.py
+++ b/runtests.py
@@ -4,7 +4,7 @@ import sys
 from django.conf import global_settings, settings
 
 OUR_MIDDLEWARE = []
-OUR_MIDDLEWARE.extend(global_settings.MIDDLEWARE_CLASSES)
+OUR_MIDDLEWARE.extend(global_settings.MIDDLEWARE)
 OUR_MIDDLEWARE.extend([
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -23,7 +23,7 @@ settings.configure(
         'friendship.tests',
     ],
     ROOT_URLCONF='friendship.urls',
-    MIDDLEWARE_CLASSES=OUR_MIDDLEWARE,
+    MIDDLEWARE=OUR_MIDDLEWARE,
     TEMPLATES=[
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
On models with ForeignKey the on_delete parameter is a requirement now.
The default is models.CASCADE, so that is now being used.

The migrations are also changed because they now require it too. Only
the existing one has been modified, because otherwise django would
complain. The default on_delete is used anyway, so it shouldn't matter.

Replace deprecated assignment_tag with simple_tag.

Closes #68 

If you need `django-friendship` but this PR isn't merged yet, use the below command to pip install from this branch:
```
pip install git+git://github.com/adamyala/django-friendship.git@django2.0
```