### PR TITLE
Views: show only friendship requests for the current user

### DIFF
--- a/friendship/views.py
+++ b/friendship/views.py
@@ -86,8 +86,9 @@ def friendship_cancel(request, friendship_request_id):
 @login_required
 def friendship_request_list(request, template_name='friendship/friend/requests_list.html'):
     """ View unread and read friendship requests """
-    # friendship_requests = Friend.objects.requests(request.user)
-    friendship_requests = FriendshipRequest.objects.filter(rejected__isnull=True)
+    friendship_requests = Friend.objects.requests(request.user)
+    # This shows all friendship requests in the database
+    # friendship_requests = FriendshipRequest.objects.filter(rejected__isnull=True)
 
     return render(request, template_name, {'requests': friendship_requests})
 


### PR DESCRIPTION
There were two queries in the friendship_requests_list view, one of which was commented.

The uncommented one retrieved from the database all friendship requests, while the commented line was the right one, which only showed friendship requests coming from the User in the request object.

I think that the desirable behavior, out-of-the-box, should be the one i proposed, since this could be a security hole if the developer using this package doesn't realize this and includes the django-friendship urlconf in his project.

I ran the file runtests.py afterwards to check for errors and everything was alright after the change.