### PR TITLE
Fix django.utils.translation.ugettext_lazy() is deprecated (#134)

### DIFF
--- a/friendship/models.py
+++ b/friendship/models.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from friendship.exceptions import AlreadyExistsError, AlreadyFriendsError
 from friendship.signals import (


### PR DESCRIPTION
Fixes #134 