### PR TITLE
BlockManager.blocked bug fix

### DIFF
--- a/friendship/models.py
+++ b/friendship/models.py
@@ -534,7 +534,7 @@ class BlockManager(models.Manager):
         return blocking
 
     def add_block(self, blocker, blocked):
-        """ Create 'follower' follows 'followee' relationship """
+        """ Create 'blocker' blocks 'blocked' relationship """
         if blocker == blocked:
             raise ValidationError("Users cannot block themselves")
 

--- a/friendship/models.py
+++ b/friendship/models.py
@@ -516,7 +516,7 @@ class BlockManager(models.Manager):
 
         if blocked is None:
             qs = Block.objects.filter(blocked=user).all()
-            blocked = [u.blocked for u in qs]
+            blocked = [u.blocker for u in qs]
             cache.set(key, blocked)
 
         return blocked

--- a/friendship/tests/tests.py
+++ b/friendship/tests/tests.py
@@ -263,7 +263,9 @@ class FriendshipModelTests(BaseTestCase):
         # Bob blocks Steve
         Block.objects.add_block(self.user_bob, self.user_steve)
         self.assertEqual(len(Block.objects.blocking(self.user_bob)), 1)
+        self.assertEqual(Block.objects.blocking(self.user_bob)[0], self.user_steve)
         self.assertEqual(len(Block.objects.blocked(self.user_steve)), 1)
+        self.assertEqual(Block.objects.blocked(self.user_steve)[0], self.user_bob)
         self.assertEqual(Block.objects.is_blocked(self.user_bob, self.user_steve), True)
 
         # Duplicated requests raise a more specific subclass of IntegrityError.


### PR DESCRIPTION
Hello,
First of all thanks for the great project!
I came into a bug recently. It seems that the function `blocked` from `BlockManager` is returning wrong values. 
There is also an issue for this https://github.com/revsys/django-friendship/issues/80
(Resolves #80)

I tried to address the issue and extended the test to capture this.