### PR TITLE
runtests.py: add dummy SECRET_KEY

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -22,6 +22,7 @@ OUR_MIDDLEWARE.extend(
 
 settings.configure(
     DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory;"}},
+    SECRET_KEY="secret",
     INSTALLED_APPS=[
         "django.contrib.auth",
         "django.contrib.sessions",


### PR DESCRIPTION
I was trying to run the tests locally but got the following errors with latest Django

```
django.core.exceptions.ImproperlyConfigured: The SECRET_KEY setting must not be empty.
```
