### PR TITLE
:arrow_up: Upgrade Python test version to 3.10

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,7 +23,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10-dev"
+          - "3.10"
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
This change does not require a release. 