### PR TITLE
Support FriendshipRequest select related strategies in FriendshipManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Then use any of the following:
 ```python
 FRIENDSHIP_CONTEXT_OBJECT_NAME = 'user'
 FRIENDSHIP_CONTEXT_OBJECT_LIST_NAME = 'users'
+FRIENDSHIP_MANAGER_FRIENDSHIP_REQUEST_SELECT_RELATED_STRATEGY = 'select_related'  # ('select_related', 'prefetch_related', 'none')
 ```
 
 ### Contributing

--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ Then use any of the following:
 - block_created
 - block_removed
 
+### Settings
+
+```python
+FRIENDSHIP_CONTEXT_OBJECT_NAME = 'user'
+FRIENDSHIP_CONTEXT_OBJECT_LIST_NAME = 'users'
+```
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Then use any of the following:
 
 ### Settings
 
+`django-friendship` supports the following settings:
+
 ```python
 FRIENDSHIP_CONTEXT_OBJECT_NAME = 'user'
 FRIENDSHIP_CONTEXT_OBJECT_LIST_NAME = 'users'

--- a/friendship/models.py
+++ b/friendship/models.py
@@ -223,7 +223,7 @@ class FriendshipManager(models.Manager):
 
         if count is None:
             count = (
-                FriendshipRequest.objects.select_related("from_user", "to_user")
+                FriendshipRequest.objects
                 .filter(to_user=user, viewed__isnull=True)
                 .count()
             )
@@ -280,7 +280,7 @@ class FriendshipManager(models.Manager):
 
         if count is None:
             count = (
-                FriendshipRequest.objects.select_related("from_user", "to_user")
+                FriendshipRequest.objects
                 .filter(to_user=user, rejected__isnull=True)
                 .count()
             )

--- a/friendship/models.py
+++ b/friendship/models.py
@@ -180,9 +180,8 @@ class FriendshipManager(models.Manager):
         requests = cache.get(key)
 
         if requests is None:
-            qs = FriendshipRequest.objects.select_related(
-                "from_user", "to_user"
-            ).filter(to_user=user)
+            qs = FriendshipRequest.objects.filter(to_user=user)
+            qs = self._friendship_request_select_related(qs, "from_user", "to_user")
             requests = list(qs)
             cache.set(key, requests)
 
@@ -194,9 +193,8 @@ class FriendshipManager(models.Manager):
         requests = cache.get(key)
 
         if requests is None:
-            qs = FriendshipRequest.objects.select_related(
-                "from_user", "to_user"
-            ).filter(from_user=user)
+            qs = FriendshipRequest.objects.filter(from_user=user)
+            qs = self._friendship_request_select_related(qs, "from_user", "to_user")
             requests = list(qs)
             cache.set(key, requests)
 
@@ -208,9 +206,8 @@ class FriendshipManager(models.Manager):
         unread_requests = cache.get(key)
 
         if unread_requests is None:
-            qs = FriendshipRequest.objects.select_related(
-                "from_user", "to_user"
-            ).filter(to_user=user, viewed__isnull=True)
+            qs = FriendshipRequest.objects.filter(to_user=user, viewed__isnull=True)
+            qs = self._friendship_request_select_related(qs, "from_user", "to_user")
             unread_requests = list(qs)
             cache.set(key, unread_requests)
 
@@ -237,9 +234,8 @@ class FriendshipManager(models.Manager):
         read_requests = cache.get(key)
 
         if read_requests is None:
-            qs = FriendshipRequest.objects.select_related(
-                "from_user", "to_user"
-            ).filter(to_user=user, viewed__isnull=False)
+            qs = FriendshipRequest.objects.filter(to_user=user, viewed__isnull=False)
+            qs = self._friendship_request_select_related(qs, "from_user", "to_user")
             read_requests = list(qs)
             cache.set(key, read_requests)
 
@@ -251,9 +247,8 @@ class FriendshipManager(models.Manager):
         rejected_requests = cache.get(key)
 
         if rejected_requests is None:
-            qs = FriendshipRequest.objects.select_related(
-                "from_user", "to_user"
-            ).filter(to_user=user, rejected__isnull=False)
+            qs = FriendshipRequest.objects.filter(to_user=user, rejected__isnull=False)
+            qs = self._friendship_request_select_related(qs, "from_user", "to_user")
             rejected_requests = list(qs)
             cache.set(key, rejected_requests)
 
@@ -265,9 +260,8 @@ class FriendshipManager(models.Manager):
         unrejected_requests = cache.get(key)
 
         if unrejected_requests is None:
-            qs = FriendshipRequest.objects.select_related(
-                "from_user", "to_user"
-            ).filter(to_user=user, rejected__isnull=True)
+            qs = FriendshipRequest.objects.filter(to_user=user, rejected__isnull=True)
+            qs = self._friendship_request_select_related(qs, "from_user", "to_user")
             unrejected_requests = list(qs)
             cache.set(key, unrejected_requests)
 
@@ -358,6 +352,9 @@ class FriendshipManager(models.Manager):
                 return True
             except Friend.DoesNotExist:
                 return False
+
+    def _friendship_request_select_related(self, qs, *fields):
+        return qs.select_related(*fields)
 
 
 class Friend(models.Model):

--- a/friendship/models.py
+++ b/friendship/models.py
@@ -354,7 +354,12 @@ class FriendshipManager(models.Manager):
                 return False
 
     def _friendship_request_select_related(self, qs, *fields):
-        return qs.select_related(*fields)
+        strategy = getattr(settings, "FRIENDSHIP_MANAGER_FRIENDSHIP_REQUEST_SELECT_RELATED_STRATEGY", "select_related")
+        if strategy == "select_related":
+            qs = qs.select_related(*fields)
+        elif strategy == "prefetch_related":
+            qs = qs.prefetch_related(*fields)
+        return qs
 
 
 class Friend(models.Model):


### PR DESCRIPTION
Resolves #169

Let's support `'prefetch_related'` and `'none'` strategies, with `'select_related'` as default for backward compatibility.

### `'prefetch_related'`

`prefetch_related` will help with the cache item size.

From https://docs.djangoproject.com/en/4.0/ref/models/querysets/#prefetch-related:
> One difference to note when using `prefetch_related` is that objects created by a query can be shared between the different objects that they are related to i.e. a single Python model instance can appear at more than one point in the tree of objects that are returned. This will normally happen with foreign key relationships. Typically this behavior will not be a problem, and will in fact save both memory and CPU time.

Though this potential performance problem should be noted.

From https://docs.djangoproject.com/en/4.0/ref/models/querysets/#prefetch-related:
> `prefetch_related` in most cases will be implemented using an SQL query that uses the ‘IN’ operator. This means that for a large `QuerySet` a large ‘IN’ clause could be generated, which, depending on the database, might have performance problems of its own when it comes to parsing or executing the SQL query. Always profile for your use case!

### `'none'`

Some projects don't access `from_user` and `to_user` fields.

---

This PR also:
- removed `select_related` for `count` queries in `FriendshipManager` methods:
  - `unread_request_count`
  - `unrejected_request_count`
- documented settings in README.md:
  - `FRIENDSHIP_CONTEXT_OBJECT_NAME`
  - `FRIENDSHIP_CONTEXT_OBJECT_LIST_NAME`
  - `FRIENDSHIP_MANAGER_FRIENDSHIP_REQUEST_SELECT_RELATED_STRATEGY`