### PR TITLE
docs: fix simple typo, canot -> cannot

### DIFF
--- a/friendship/tests/tests.py
+++ b/friendship/tests/tests.py
@@ -252,7 +252,7 @@ class FriendshipModelTests(BaseTestCase):
         self.assertEqual(len(Follow.objects.following(self.user_bob)), 0)
         self.assertFalse(Follow.objects.follows(self.user_bob, self.user_steve))
 
-        # Ensure we canot follow ourselves
+        # Ensure we cannot follow ourselves
         with self.assertRaises(ValidationError):
             Follow.objects.add_follower(self.user_bob, self.user_bob)
 
@@ -280,7 +280,7 @@ class FriendshipModelTests(BaseTestCase):
         self.assertEqual(len(Block.objects.blocking(self.user_steve)), 0)
         self.assertEqual(len(Block.objects.blocked(self.user_bob)), 0)
 
-        # Ensure we canot block ourselves
+        # Ensure we cannot block ourselves
         with self.assertRaises(ValidationError):
             Block.objects.add_block(self.user_bob, self.user_bob)
 


### PR DESCRIPTION
There is a small typo in friendship/tests/tests.py.

Should read `cannot` rather than `canot`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md