### PR TITLE
Bust sent_requests cache on reject

### DIFF
--- a/friendship/models.py
+++ b/friendship/models.py
@@ -141,6 +141,7 @@ class FriendshipRequest(models.Model):
         self.save()
         friendship_request_rejected.send(sender=self)
         bust_cache("requests", self.to_user.pk)
+        bust_cache("sent_requests", self.from_user.pk)
         return True
 
     def cancel(self):

--- a/friendship/tests/tests.py
+++ b/friendship/tests/tests.py
@@ -141,7 +141,11 @@ class FriendshipModelTests(BaseTestCase):
         req3 = Friend.objects.add_friend(self.user_susan, self.user_amy)
         self.assertEqual(Friend.objects.friends(self.user_susan), [])
         self.assertEqual(Friend.objects.friends(self.user_amy), [])
+        self.assertEqual(len(Friend.objects.sent_requests(self.user_susan)), 1)
+        self.assertIsNone(Friend.objects.sent_requests(self.user_susan)[0].rejected)
         req3.reject()
+        self.assertEqual(len(Friend.objects.sent_requests(self.user_susan)), 1)
+        self.assertIsNotNone(Friend.objects.sent_requests(self.user_susan)[0].rejected)
 
         # Duplicated requests raise a more specific subclass of IntegrityError.
         with self.assertRaises(AlreadyExistsError):


### PR DESCRIPTION
Fixes #175

Missed out in #28, which bust `sent_requests` cache on `accept`, `cancel` and `add_friend`.