### PR TITLE
Fix Follow/Block created signals to send the model as sender (#89)

### DIFF
--- a/friendship/models.py
+++ b/friendship/models.py
@@ -405,9 +405,9 @@ class FollowingManager(models.Manager):
         if created is False:
             raise AlreadyExistsError(f"User '{follower}' already follows '{followee}'")
 
-        follower_created.send(sender=self, follower=follower)
-        followee_created.send(sender=self, followee=followee)
-        following_created.send(sender=self, following=relation)
+        follower_created.send(sender=self.model, follower=follower)
+        followee_created.send(sender=self.model, followee=followee)
+        following_created.send(sender=self.model, following=relation)
 
         bust_cache("followers", followee.pk)
         bust_cache("following", follower.pk)
@@ -500,9 +500,9 @@ class BlockManager(models.Manager):
         if created is False:
             raise AlreadyExistsError(f"User '{blocker}' already blocks '{blocked}'")
 
-        block_created.send(sender=self, blocker=blocker)
-        block_created.send(sender=self, blocked=blocked)
-        block_created.send(sender=self, blocking=relation)
+        block_created.send(sender=self.model, blocker=blocker)
+        block_created.send(sender=self.model, blocked=blocked)
+        block_created.send(sender=self.model, blocking=relation)
 
         bust_cache("blocked", blocked.pk)
         bust_cache("blocking", blocker.pk)

--- a/friendship/tests/tests.py
+++ b/friendship/tests/tests.py
@@ -9,6 +9,12 @@ from django.urls import reverse
 
 from friendship.exceptions import AlreadyExistsError, AlreadyFriendsError
 from friendship.models import Block, Follow, Friend, FriendshipRequest
+from friendship.signals import (
+    block_created,
+    followee_created,
+    follower_created,
+    following_created,
+)
 
 TEST_TEMPLATES = os.path.join(os.path.dirname(__file__), "templates")
 
@@ -628,3 +634,42 @@ class FriendshipViewTests(BaseTestCase):
             self.assertResponse302(response)
             redirect_url = reverse("friendship_blocking", kwargs={"username": self.user_bob.username})
             self.assertTrue(redirect_url in response["Location"])
+
+
+class SignalTests(BaseTestCase):
+    """
+    Signals should be sent with ``sender`` set to the model class so that
+    receivers connected with ``sender=Follow`` / ``sender=Block`` actually fire.
+    Regression test for #89.
+    """
+
+    def _collect(self, signal, sender):
+        received = []
+
+        def handler(sender, **kwargs):
+            received.append(kwargs)
+
+        signal.connect(handler, sender=sender, weak=False)
+        self.addCleanup(signal.disconnect, handler, sender=sender)
+        return received
+
+    def test_follow_created_signals_fire_with_model_sender(self):
+        followers = self._collect(follower_created, Follow)
+        followees = self._collect(followee_created, Follow)
+        followings = self._collect(following_created, Follow)
+
+        Follow.objects.add_follower(self.user_bob, self.user_steve)
+
+        self.assertEqual(len(followers), 1)
+        self.assertEqual(followers[0]["follower"], self.user_bob)
+        self.assertEqual(len(followees), 1)
+        self.assertEqual(followees[0]["followee"], self.user_steve)
+        self.assertEqual(len(followings), 1)
+
+    def test_block_created_signals_fire_with_model_sender(self):
+        blocks = self._collect(block_created, Block)
+
+        Block.objects.add_block(self.user_bob, self.user_steve)
+
+        # add_block emits block_created three times (blocker, blocked, blocking)
+        self.assertEqual(len(blocks), 3)


### PR DESCRIPTION
Fixes #89.

## Problem
`FollowingManager.add_follower` and `BlockManager.add_block` emitted their `*_created` signals with `sender=self` — i.e. the **manager instance**. Receivers connected the documented way (`@receiver(follower_created, sender=Follow)`) never matched, so the signals appeared to "not work."

## Fix
Send `sender=self.model` (the `Follow` / `Block` class) instead. This is the exact change suggested in the issue, applied to both the follow signals (`follower_created`, `followee_created`, `following_created`) and the block signals (`block_created`) called out as "potentially others."

## Tests
Added `SignalTests` that connect receivers with `sender=Follow` / `sender=Block` and assert they fire. Verified they **fail** on the old `sender=self` code and **pass** with the fix. Full suite (26 tests) green, lint clean.

## Note / not in scope
The `*_removed` signals still send `sender=<instance>` (e.g. `sender=rel`), which also won't match `sender=Follow`. Left unchanged here to keep this focused on the reported `_created` bug — happy to follow up separately if you want removed signals to use the model sender too.