### PR TITLE
Use str URL converter for usernames so non-slug usernames reverse (#109)

### DIFF
--- a/friendship/tests/tests.py
+++ b/friendship/tests/tests.py
@@ -673,3 +673,39 @@ class SignalTests(BaseTestCase):
 
         # add_block emits block_created three times (blocker, blocked, blocking)
         self.assertEqual(len(blocks), 3)
+
+
+class UsernameUrlTests(BaseTestCase):
+    """
+    Usernames may contain characters outside the slug charset (Django's default
+    validator allows ``@``, ``.``, ``+``, ``-``, ``_`` and unicode). The bundled
+    URLs must reverse for those usernames. Regression test for #109.
+    """
+
+    # A username the ``slug`` converter would reject but ``UsernameValidator`` allows.
+    DOTTED = "bob.smith"
+
+    def test_username_urls_reverse_with_non_slug_characters(self):
+        for name, kwarg in [
+            ("friendship_view_friends", "username"),
+            ("friendship_add_friend", "to_username"),
+            ("friendship_followers", "username"),
+            ("friendship_following", "username"),
+            ("follower_add", "followee_username"),
+            ("follower_remove", "followee_username"),
+            ("friendship_blockers", "username"),
+            ("friendship_blocking", "username"),
+            ("block_add", "blocked_username"),
+            ("block_remove", "blocked_username"),
+        ]:
+            with self.subTest(url=name):
+                # Previously raised NoReverseMatch under the ``slug`` converter.
+                reverse(name, kwargs={kwarg: self.DOTTED})
+
+    def test_users_page_renders_when_a_username_has_a_dot(self):
+        # The user list template reverses ``friendship_add_friend`` for every
+        # user, so a single dotted username used to 500 the whole page.
+        self.create_user(self.DOTTED, "dotted@example.com", self.user_pw)
+        with self.login(self.user_bob.username, self.user_pw):
+            response = self.client.get(reverse("friendship_view_users"))
+            self.assertResponse200(response)

--- a/friendship/urls.py
+++ b/friendship/urls.py
@@ -23,12 +23,12 @@ from friendship.views import (
 urlpatterns = [
     path("users/", view=all_users, name="friendship_view_users"),
     path(
-        "friends/<slug:username>/",
+        "friends/<str:username>/",
         view=view_friends,
         name="friendship_view_friends",
     ),
     path(
-        "friend/add/<slug:to_username>/",
+        "friend/add/<str:to_username>/",
         view=friendship_add_friend,
         name="friendship_add_friend",
     ),
@@ -63,42 +63,42 @@ urlpatterns = [
         name="friendship_requests_detail",
     ),
     path(
-        "followers/<slug:username>/",
+        "followers/<str:username>/",
         view=followers,
         name="friendship_followers",
     ),
     path(
-        "following/<slug:username>/",
+        "following/<str:username>/",
         view=following,
         name="friendship_following",
     ),
     path(
-        "follower/add/<slug:followee_username>/",
+        "follower/add/<str:followee_username>/",
         view=follower_add,
         name="follower_add",
     ),
     path(
-        "follower/remove/<slug:followee_username>/",
+        "follower/remove/<str:followee_username>/",
         view=follower_remove,
         name="follower_remove",
     ),
     path(
-        "blockers/<slug:username>/",
+        "blockers/<str:username>/",
         view=blockers,
         name="friendship_blockers",
     ),
     path(
-        "blocking/<slug:username>/",
+        "blocking/<str:username>/",
         view=blocking,
         name="friendship_blocking",
     ),
     path(
-        "block/add/<slug:blocked_username>/",
+        "block/add/<str:blocked_username>/",
         view=block_add,
         name="block_add",
     ),
     path(
-        "block/remove/<slug:blocked_username>/",
+        "block/remove/<str:blocked_username>/",
         view=block_remove,
         name="block_remove",
     ),


### PR DESCRIPTION
Fixes #109.

## Problem
The bundled URLs captured usernames with the `slug` path converter, which only matches `[-a-zA-Z0-9_]+`. Django's default username validator allows `@ . + - _` and unicode, so a username like `bob.smith` raised `NoReverseMatch`. Because the user-list template reverses `friendship_add_friend`/`follower_add` for **every** user, a single dotted username 500'd the whole `/users/` page — the exact symptom reported.

## Fix
Switch the 10 username captures from `<slug:…>` to `<str:…>` (the `str` converter matches `[^/]+`, covering the full valid username charset including unicode). Integer captures (`friendship_request_id`) are unchanged. No view signatures change — only the matching.

## Tests
- `UsernameUrlTests.test_username_urls_reverse_with_non_slug_characters` — reverses all 10 username URLs with a dotted username (subtests).
- `test_users_page_renders_when_a_username_has_a_dot` — reproduces the reported 500 by GETting `/users/` with a dotted user in the DB.

Both **fail** on the old `slug` converter (11 failures) and **pass** with `str`. Full suite (26 + 10 subtests) green, lint clean.