### PR TITLE
Convert CHANGELOG to Markdown, record 1.10.0, add Unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,175 +1,165 @@
-Unreleased
-----------
+# Changelog
 
-*Not released yet*
+## Unreleased
 
-- Fix ``Follow`` and ``Block`` ``*_created`` signals to send the model class as
-  ``sender`` so receivers connected with ``sender=Follow`` / ``sender=Block``
+_Not released yet_
+
+- Fix `Follow` and `Block` `*_created` signals to send the model class as
+  `sender` so receivers connected with `sender=Follow` / `sender=Block`
   fire (#89)
-- Use the ``str`` URL converter for usernames so usernames containing ``.``,
-  ``@``, ``+`` or unicode reverse correctly instead of raising
-  ``NoReverseMatch`` (#109)
+- Use the `str` URL converter for usernames so usernames containing `.`,
+  `@`, `+` or unicode reverse correctly instead of raising
+  `NoReverseMatch` (#109)
 
-Version 1.10.0
---------------
+## Version 1.10.0
 
-*Released July 30th, 2026*
+_Released July 30th, 2026_
 
 - Add support for Django 4.2, 5.0, 5.1, 5.2, 6.0, and 6.1
 - Add support for Python 3.10 through 3.14, including free-threaded 3.14
-- Move packaging to ``pyproject.toml`` with the hatchling build backend and
+- Move packaging to `pyproject.toml` with the hatchling build backend and
   modernize tooling (nox test matrix, ruff/prek pre-commit, split CI workflows)
-- Add ability to use ``prefetch_related`` rather than ``select_related`` for
+- Add ability to use `prefetch_related` rather than `select_related` for
   memory/cache size reduction
 - Fix signal sending issue on cancel after object is deleted
 
-Version 1.9.6
--------------
-*Released March 13th, 2022*
+## Version 1.9.6
+
+_Released March 13th, 2022_
 
 - ORM performance improvements
 
-Version 1.9.5
--------------
-*Released March 13th, 2022*
+## Version 1.9.5
+
+_Released March 13th, 2022_
 
 - Officially support Django 4.0 in trove classifiers
 
-Version 1.9.4
--------------
-*Released October 5th, 2021*
+## Version 1.9.4
+
+_Released October 5th, 2021_
 
 - Fix bumpversion related release issue
 
-Version 1.9.3
--------------
-*Released October 4th, 2021*
+## Version 1.9.3
+
+_Released October 4th, 2021_
 
 - Fix PyPI deploy process to use main instead of master (actually release what should have been in 1.9.2)
 - Fix Django deprecation warnings
 
-Version 1.9.2
--------------
-*Released August 25th 2021*
+## Version 1.9.2
+
+_Released August 25th 2021_
 
 - Broken release, mostly a duplicate of 1.9.1 due to branch renaming issue
 
-Version 1.9.1
--------------
+## Version 1.9.1
 
-*Released April 9th, 2020*
+_Released April 9th, 2020_
 
 - Add missing migration.
 
-Version 1.9.0
--------------
+## Version 1.9.0
 
-*Released April 7th, 2020*
+_Released April 7th, 2020_
 
 - Drop support for Python 2
 - Add support for Django 3.0
 
-Version 1.8.2
--------------
+## Version 1.8.2
 
-*Released November 27th, 2019*
+_Released November 27th, 2019_
 
 - Fixed bug with viewing rejected friend requests
 - Added friends QuerySet to view context
 - Reduce fields queried when not necessary
 - Update Travis to check Python 3.8
 
-Version 1.8.1
--------------
+## Version 1.8.1
 
-*Released May 24th, 2019*
+_Released May 24th, 2019_
 
 - Fixed bug in `friendship_request_list` view
 - Refactored `can_request_send` to be more clear
 - Ran Black over the codebase
 
-Version 1.8.0
--------------
+## Version 1.8.0
 
-*Released July 6th, 2018*
+_Released July 6th, 2018_
 
 - Fix migrations for people migrating from <= 1.5.x.
   If you are migrating from 1.6 or 1.7, please rollback django-friendships
-  migrations to 0001 and migrate-fake 0002::
+  migrations to 0001 and migrate-fake 0002:
 
-    $ ./manage.py migrate friendship 0001
-    $ ./manage.py migrate friendship 0002 --fake
+  ```
+  $ ./manage.py migrate friendship 0001
+  $ ./manage.py migrate friendship 0002 --fake
+  ```
 
-  If you're migrating from ``v1.7.x``, you'll likely have to fake ``0003`` as well::
+  If you're migrating from `v1.7.x`, you'll likely have to fake `0003` as well:
 
-    $ ./manage.py migrate friendship 0003 --fake
+  ```
+  $ ./manage.py migrate friendship 0003 --fake
+  ```
 
-Version 1.7.1
--------------
+## Version 1.7.1
 
-*Released July 5th, 2018*
+_Released July 5th, 2018_
 
 - Bugfix, missing migration
 
-Version 1.7.0
--------------
+## Version 1.7.0
 
-*Released July 2nd, 2018*
+_Released July 2nd, 2018_
 
 - Add support for Django 2.0
 - Drop support for Django < 1.11
 
-Version 1.6.0
--------------
+## Version 1.6.0
 
-*Released May 22nd, 2018*
+_Released May 22nd, 2018_
 
 - Added can_request_send option (narnikgamarnik)
 - Added blocking feature (Darren Mckeeman)
 
-Version 1.5.0
--------------
+## Version 1.5.0
 
-*Released August 21st, 2016*
+_Released August 21st, 2016_
 
 - Added support for Django 1.10
 
-Version 1.4.0
--------------
+## Version 1.4.0
 
-*Released July 23rd, 2016*
+_Released July 23rd, 2016_
 
 - Moved template tag to assignment_tag to avoid Django 1.9 error
 
-Version 1.3.3
--------------
+## Version 1.3.3
 
-*Released July 1st, 2016*
+_Released July 1st, 2016_
 
 - Support non-integer primary keys in cache keys
 - Remove support for Django 1.4
 
-Version 1.3.1
--------------
+## Version 1.3.1
 
-*Released November 11th, 2015*
+_Released November 11th, 2015_
 
 - Raise AlreadyFriendError if creating request when users are already friends
 - PEP8 cleanups
 
-Version 1.3.0
--------------
+## Version 1.3.0
 
-*Released July 12th, 2015*
+_Released July 12th, 2015_
 
 - Updated Django 1.7 and 1.8 compatibility
 - Signal related bug fixes
 - Python 3 compatibility
 
-Version 1.2.0
--------------
+## Version 1.2.0
 
-*Released September 22nd, 2014*
+_Released September 22nd, 2014_
 
 - Updated test runner for 1.7 compatibility
 - Fixed security issue where we were not checking the owner of a FriendRequest during accept and
@@ -177,19 +167,17 @@ Version 1.2.0
 - Added optional 'message' kwarg to FriendshipManager.add_friend() so it is easier to set the
   optional message field on FriendshipRequests
 
-Version 1.1.0
--------------
+## Version 1.1.0
 
-*Released May 6th, 2014*
+_Released May 6th, 2014_
 
 - Added Django 1.7 compatibility.
 - Fixed caching issue with sent_requests.
 - Added unrejected_requests() and unrejected_request_count() manager methods.
 
-Version 1.0.0
--------------
+## Version 1.0.0
 
-*Released November 13th, 2013*
+_Released November 13th, 2013_
 
 - Fixed bug where FriendRequests could be left hanging if both sides requested friendship prior to
   one side accepting.  Caused exception if the user accepted the second request.
@@ -197,7 +185,6 @@ Version 1.0.0
 - Fixed Django 1.6 compatibility issue
 - 1.0 release whoo hoo!
 
-Changes prior to version 0.9.0
-------------------------------
+## Changes prior to version 0.9.0
 
 Lots.  We didn't keep good track of issues prior to 1.0.0.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,26 @@
-Version 2.0.0
--------------
+Unreleased
+----------
+
 *Not released yet*
 
-- Add ability to use `prefetch_related` rather than `select_related` for memory/cache size reduction
+- Fix ``Follow`` and ``Block`` ``*_created`` signals to send the model class as
+  ``sender`` so receivers connected with ``sender=Follow`` / ``sender=Block``
+  fire (#89)
+- Use the ``str`` URL converter for usernames so usernames containing ``.``,
+  ``@``, ``+`` or unicode reverse correctly instead of raising
+  ``NoReverseMatch`` (#109)
+
+Version 1.10.0
+--------------
+
+*Released July 30th, 2026*
+
+- Add support for Django 4.2, 5.0, 5.1, 5.2, 6.0, and 6.1
+- Add support for Python 3.10 through 3.14, including free-threaded 3.14
+- Move packaging to ``pyproject.toml`` with the hatchling build backend and
+  modernize tooling (nox test matrix, ruff/prek pre-commit, split CI workflows)
+- Add ability to use ``prefetch_related`` rather than ``select_related`` for
+  memory/cache size reduction
 - Fix signal sending issue on cancel after object is deleted
 
 Version 1.9.6
@@ -170,6 +188,8 @@ Version 1.1.0
 
 Version 1.0.0
 -------------
+
+*Released November 13th, 2013*
 
 - Fixed bug where FriendRequests could be left hanging if both sides requested friendship prior to
   one side accepting.  Caused exception if the user accepted the second request.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ file = "README.md"
 content-type = "text/markdown"
 
 [project.urls]
-Changelog = "https://github.com/revsys/django-friendship/blob/main/CHANGELOG.rst"
+Changelog = "https://github.com/revsys/django-friendship/blob/main/CHANGELOG.md"
 Homepage = "https://github.com/revsys/django-friendship/"
 
 [project.optional-dependencies]
@@ -91,7 +91,7 @@ packages = ["friendship"]
 [tool.hatch.build.targets.sdist]
 include = [
     "/friendship",
-    "/CHANGELOG.rst",
+    "/CHANGELOG.md",
     "/README.md",
 ]
 


### PR DESCRIPTION
Brings the changelog in sync with what shipped, converts it to Markdown, and sets up ongoing maintenance.

## Changes
- **Convert `CHANGELOG.rst` → `CHANGELOG.md`** (git-tracked rename). RST syntax converted to Markdown: `---` underline headers → `##`, ```code``` → ``code``, `*Released …*` → `_Released …_`, and the `::` migrate literal block → a fenced code block. Updated both references in `pyproject.toml` (the `project.urls` Changelog link and the sdist `include`).
- **Add an `Unreleased` section** for the just-merged fixes: signal `sender` fix (#89) and the `str` username URL converter (#109).
- **Record `Version 1.10.0` (Released July 30th, 2026)** — the Django 4.2–6.1 / Python 3.10–3.14t support and packaging modernization, folding in the `prefetch_related` and cancel-signal bullets that shipped with it (moved down from the stale, never-released `2.0.0` heading).
- **Backfill the `1.0.0` release date** (November 13th, 2013, from tag `v1.0.0`).

## Verified
- No `CHANGELOG.rst` references remain in the repo.
- `uv build` sdist contains `CHANGELOG.md`.
- Lint clean.

## Note on versioning
The old `2.0.0` heading is mapped to `1.10.0` because that's the version published to PyPI. The `Unreleased` section stays version-agnostic so the next release can be whatever it warrants.