### PR TITLE
Add FriendshipManager.request_exists() helper (#198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ _Not released yet_
 - Use the `str` URL converter for usernames so usernames containing `.`,
   `@`, `+` or unicode reverse correctly instead of raising
   `NoReverseMatch` (#109)
+- Add `FriendshipManager.request_exists(from_user, to_user)` to check for a
+  pending friendship request in either direction without duplicating the
+  queries (#198)
 
 ## Version 1.10.0
 

--- a/friendship/models.py
+++ b/friendship/models.py
@@ -270,6 +270,17 @@ class FriendshipManager(models.Manager):
 
         return count
 
+    def request_exists(self, from_user, to_user):
+        """Return ``True`` if a friendship request exists between the two users
+        in either direction.
+
+        Useful for checking whether ``add_friend`` would raise
+        ``AlreadyExistsError`` without having to duplicate the queries here.
+        """
+        return FriendshipRequest.objects.filter(
+            models.Q(from_user=from_user, to_user=to_user) | models.Q(from_user=to_user, to_user=from_user)
+        ).exists()
+
     def add_friend(self, from_user, to_user, message=None):
         """Create a friendship request"""
         if from_user == to_user:

--- a/friendship/tests/tests.py
+++ b/friendship/tests/tests.py
@@ -709,3 +709,31 @@ class UsernameUrlTests(BaseTestCase):
         with self.login(self.user_bob.username, self.user_pw):
             response = self.client.get(reverse("friendship_view_users"))
             self.assertResponse200(response)
+
+
+class RequestExistsTests(BaseTestCase):
+    """Tests for FriendshipManager.request_exists (#198)."""
+
+    def test_false_when_no_request(self):
+        self.assertFalse(Friend.objects.request_exists(self.user_bob, self.user_steve))
+
+    def test_true_in_both_directions(self):
+        Friend.objects.add_friend(self.user_bob, self.user_steve)
+
+        # request_exists is direction-agnostic: it reports the pending request
+        # regardless of which user is passed first.
+        self.assertTrue(Friend.objects.request_exists(self.user_bob, self.user_steve))
+        self.assertTrue(Friend.objects.request_exists(self.user_steve, self.user_bob))
+
+    def test_unaffected_by_unrelated_users(self):
+        Friend.objects.add_friend(self.user_bob, self.user_steve)
+
+        self.assertFalse(Friend.objects.request_exists(self.user_bob, self.user_susan))
+        self.assertFalse(Friend.objects.request_exists(self.user_susan, self.user_amy))
+
+    def test_matches_add_friend_guard(self):
+        # Whenever request_exists is True, add_friend should refuse.
+        Friend.objects.add_friend(self.user_bob, self.user_steve)
+        self.assertTrue(Friend.objects.request_exists(self.user_steve, self.user_bob))
+        with self.assertRaises(AlreadyExistsError):
+            Friend.objects.add_friend(self.user_steve, self.user_bob)


### PR DESCRIPTION
Fixes #198.

## What
Adds `FriendshipManager.request_exists(from_user, to_user)` — a reusable, direction-agnostic predicate that returns `True` when a pending `FriendshipRequest` exists between two users in either direction:

```python
if Friend.objects.request_exists(from_user, to_user):
    ...
```

This lets callers check the condition that would make `add_friend` raise `AlreadyExistsError` without copying the two `FriendshipRequest.objects.filter(...).exists()` queries out of the manager — the motivation in the issue.

## Design note
The issue proposed a `check_if_request_sent()` method that **raises**. I went with a **boolean predicate** instead because a `..._exists()` name reading as a question that silently raises is a footgun, and a bool is more broadly reusable. `add_friend` is intentionally left unchanged — it keeps its own two directional checks so it can raise the *direction-specific* messages ("You already requested…" vs "This user already requested…"), which a single combined check would lose. So this PR is purely additive: **no behavior change** to existing calls.

Happy to switch to the raising variant if you'd prefer it.

## Tests
`RequestExistsTests`: false when no request, true in both directions, unaffected by unrelated users, and consistent with `add_friend`'s guard. Full suite (32 + 10 subtests) green, lint clean.

## Changelog
Added an `Unreleased` entry (maintaining the changelog as we go).