### PR TITLE
Allow re-requesting friendship after a rejection (#193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ _Not released yet_
 - Add `FriendshipManager.request_exists(from_user, to_user)` to check for a
   pending friendship request in either direction without duplicating the
   queries (#198)
+- Allow a friendship request to be sent again after it was rejected, instead of
+  raising `AlreadyExistsError` forever. The previously rejected request is
+  revived as a fresh, unread request; use the block feature to stop unwanted
+  requests. **Behavior change:** a single rejection no longer permanently blocks
+  future requests (#193)
 
 ## Version 1.10.0
 

--- a/friendship/models.py
+++ b/friendship/models.py
@@ -289,22 +289,33 @@ class FriendshipManager(models.Manager):
         if self.are_friends(from_user, to_user):
             raise AlreadyFriendsError("Users are already friends")
 
-        if FriendshipRequest.objects.filter(from_user=from_user, to_user=to_user).exists():
+        # A pending (un-rejected) request in either direction still blocks a new
+        # one. A previously rejected request no longer blocks forever: the sender
+        # may request again (#193). Use the Block feature to stop unwanted
+        # requests entirely.
+        if FriendshipRequest.objects.filter(from_user=from_user, to_user=to_user, rejected__isnull=True).exists():
             raise AlreadyExistsError("You already requested friendship from this user.")
 
-        if FriendshipRequest.objects.filter(from_user=to_user, to_user=from_user).exists():
+        if FriendshipRequest.objects.filter(from_user=to_user, to_user=from_user, rejected__isnull=True).exists():
             raise AlreadyExistsError("This user already requested friendship from you.")
 
         if message is None:
             message = ""
 
-        request, created = FriendshipRequest.objects.get_or_create(from_user=from_user, to_user=to_user)
+        request, created = FriendshipRequest.objects.get_or_create(
+            from_user=from_user,
+            to_user=to_user,
+            defaults={"message": message},
+        )
 
-        if created is False:
-            raise AlreadyExistsError("Friendship already requested")
-
-        if message:
+        if not created:
+            # The only row that can already exist here is a previously rejected
+            # request (a pending one would have raised above). Revive it as a
+            # fresh, unread request rather than blocking.
+            request.rejected = None
+            request.viewed = None
             request.message = message
+            request.created = timezone.now()
             request.save()
 
         bust_cache("requests", to_user.pk)

--- a/friendship/tests/tests.py
+++ b/friendship/tests/tests.py
@@ -143,16 +143,16 @@ class FriendshipModelTests(BaseTestCase):
         self.assertEqual(len(Friend.objects.sent_requests(self.user_susan)), 1)
         self.assertIsNotNone(Friend.objects.sent_requests(self.user_susan)[0].rejected)
 
-        # Duplicated requests raise a more specific subclass of IntegrityError.
-        with self.assertRaises(AlreadyExistsError):
-            Friend.objects.add_friend(self.user_susan, self.user_amy)
-
+        # After a rejection the sender may request again (#193); the rejected
+        # request is revived as a fresh, unread request rather than raising.
+        req3b = Friend.objects.add_friend(self.user_susan, self.user_amy)
+        self.assertIsNone(req3b.rejected)
+        self.assertEqual(len(Friend.objects.rejected_requests(self.user_amy)), 0)
+        self.assertEqual(len(Friend.objects.unread_requests(self.user_amy)), 1)
         self.assertFalse(Friend.objects.are_friends(self.user_susan, self.user_amy))
-        self.assertEqual(len(Friend.objects.rejected_requests(self.user_amy)), 1)
-        self.assertEqual(len(Friend.objects.rejected_requests(self.user_amy)), 1)
 
         # let's try that again..
-        req3.delete()
+        req3b.delete()
 
         # Susan wants to be friends with Amy, and Amy reads it
         req4 = Friend.objects.add_friend(self.user_susan, self.user_amy)
@@ -737,3 +737,51 @@ class RequestExistsTests(BaseTestCase):
         self.assertTrue(Friend.objects.request_exists(self.user_steve, self.user_bob))
         with self.assertRaises(AlreadyExistsError):
             Friend.objects.add_friend(self.user_steve, self.user_bob)
+
+
+class ResubmitAfterRejectionTests(BaseTestCase):
+    """A rejected request no longer blocks forever; the sender may try again (#193)."""
+
+    def test_can_resubmit_after_rejection(self):
+        req = Friend.objects.add_friend(self.user_bob, self.user_steve)
+        req.reject()
+
+        # Re-requesting succeeds and revives the request as fresh and unread.
+        again = Friend.objects.add_friend(self.user_bob, self.user_steve)
+        self.assertIsNone(again.rejected)
+        self.assertIsNone(again.viewed)
+        self.assertEqual(len(Friend.objects.rejected_requests(self.user_steve)), 0)
+        self.assertEqual(len(Friend.objects.unread_requests(self.user_steve)), 1)
+
+    def test_resubmit_reuses_the_same_row(self):
+        req = Friend.objects.add_friend(self.user_bob, self.user_steve)
+        req.reject()
+        again = Friend.objects.add_friend(self.user_bob, self.user_steve)
+
+        # unique_together means it's the same underlying row, revived in place.
+        self.assertEqual(again.pk, req.pk)
+        self.assertEqual(
+            FriendshipRequest.objects.filter(from_user=self.user_bob, to_user=self.user_steve).count(),
+            1,
+        )
+
+    def test_resubmit_updates_message(self):
+        Friend.objects.add_friend(self.user_bob, self.user_steve, message="hi").reject()
+        again = Friend.objects.add_friend(self.user_bob, self.user_steve, message="please?")
+        self.assertEqual(again.message, "please?")
+
+    def test_pending_request_still_blocks(self):
+        Friend.objects.add_friend(self.user_bob, self.user_steve)
+        with self.assertRaises(AlreadyExistsError):
+            Friend.objects.add_friend(self.user_bob, self.user_steve)
+
+    def test_reverse_pending_request_still_blocks(self):
+        Friend.objects.add_friend(self.user_bob, self.user_steve)
+        with self.assertRaises(AlreadyExistsError):
+            Friend.objects.add_friend(self.user_steve, self.user_bob)
+
+    def test_reverse_rejected_request_does_not_block(self):
+        # bob asks steve and is rejected; steve is now free to ask bob.
+        Friend.objects.add_friend(self.user_bob, self.user_steve).reject()
+        req = Friend.objects.add_friend(self.user_steve, self.user_bob)
+        self.assertIsNone(req.rejected)


### PR DESCRIPTION
Fixes #193.

## Problem
`FriendshipRequest` has `unique_together = (from_user, to_user)` and `reject()` keeps the row (just stamps `rejected`). `add_friend`'s existence guards matched **any** row, including rejected ones — so a single rejection permanently blocked all future requests in both directions (the sender couldn't re-ask, and the rejecter couldn't initiate either). That's an accidental dead-end, not a designed feature.

## Change
Only **pending** (un-rejected) requests block a new one. When a *rejected* request already exists between the users, `add_friend` **revives it** as a fresh, unread request (clears `rejected`/`viewed`, updates `message` and `created`, re-sends `friendship_request_created`) instead of raising.

No setting — this is the default behavior. Unwanted requests are handled by the existing **Block** feature, so there's no need to gate it.

### Behavior change
A single rejection no longer permanently blocks future requests. Called out in the changelog. Still unchanged:
- A **pending** request in either direction still raises `AlreadyExistsError`.
- Already-friends still raises `AlreadyFriendsError`; self-requests still `ValidationError`.

## Tests
- Updated the rejection assertion in `test_friendship_request` (it asserted the old permanent-block).
- Added `ResubmitAfterRejectionTests`: resubmit succeeds and is unread; row is reused (same pk, one row); message updates; pending + reverse-pending still block; a reverse rejected request doesn't block.

Full suite (38 + 10 subtests) green, lint clean. Changelog `Unreleased` entry added.