### PR TITLE
Add optional FRIENDSHIP_MAX_FRIENDS cap (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ _Not released yet_
   revived as a fresh, unread request; use the block feature to stop unwanted
   requests. **Behavior change:** a single rejection no longer permanently blocks
   future requests (#193)
+- Add an optional `FRIENDSHIP_MAX_FRIENDS` setting that caps the number of
+  friends per user, enforced when a request is accepted (raises
+  `MaxFriendsExceededError`). Unset by default, so friendships remain unlimited.
+  Adds a `FriendshipManager.friend_count(user)` helper (#82)
 
 ## Version 1.10.0
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ friend_request.accept()
 # or friend_request.reject()
 ```
 
+A rejected request does not block future requests — the sender may request
+again later. To cap how many friends a user can have, see
+[`FRIENDSHIP_MAX_FRIENDS`](#settings) under Settings.
+
 #### To remove the friendship relationship between `request.user` and `other_user`, do the following:
 
 ```python
@@ -174,6 +178,32 @@ FRIENDSHIP_CONTEXT_OBJECT_LIST_NAME = "users"
 FRIENDSHIP_MANAGER_FRIENDSHIP_REQUEST_SELECT_RELATED_STRATEGY = (
     "select_related"  # ('select_related', 'prefetch_related', 'none')
 )
+
+# Optional cap on the number of friends each user may have. Unset (the
+# default) means unlimited, so existing projects are unaffected. When set,
+# accepting a request that would put either user over the limit raises
+# friendship.exceptions.MaxFriendsExceededError.
+FRIENDSHIP_MAX_FRIENDS = 800
+```
+
+#### Limiting the number of friends
+
+By default a user may have unlimited friends. Set `FRIENDSHIP_MAX_FRIENDS` to
+cap it. The limit is checked when a request is accepted — if either user is
+already at the limit, `accept()` raises `MaxFriendsExceededError` and no
+friendship is created (the request is left intact so it can be accepted later,
+e.g. after removing another friend):
+
+```python
+from friendship.exceptions import MaxFriendsExceededError
+
+try:
+    friend_request.accept()
+except MaxFriendsExceededError:
+    ...  # tell the user their friend list is full
+
+# You can check a user's current friend count directly:
+Friend.objects.friend_count(request.user)
 ```
 
 ### Contributing

--- a/friendship/exceptions.py
+++ b/friendship/exceptions.py
@@ -7,3 +7,7 @@ class AlreadyExistsError(IntegrityError):
 
 class AlreadyFriendsError(IntegrityError):
     pass
+
+
+class MaxFriendsExceededError(Exception):
+    """Raised when accepting a request would take a user past FRIENDSHIP_MAX_FRIENDS."""

--- a/friendship/models.py
+++ b/friendship/models.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from friendship.exceptions import AlreadyExistsError, AlreadyFriendsError
+from friendship.exceptions import AlreadyExistsError, AlreadyFriendsError, MaxFriendsExceededError
 from friendship.signals import (
     block_created,
     block_removed,
@@ -108,6 +108,17 @@ class FriendshipRequest(models.Model):
 
     def accept(self):
         """Accept this friendship request"""
+        # Optional cap on friends per user. Unset (the default) means unlimited,
+        # so existing installs are unaffected. Checked before creating anything
+        # so a rejected accept leaves no partial state and the request stands.
+        max_friends = getattr(settings, "FRIENDSHIP_MAX_FRIENDS", None)
+        if max_friends is not None:
+            for user in (self.from_user, self.to_user):
+                if Friend.objects.friend_count(user) >= max_friends:
+                    raise MaxFriendsExceededError(
+                        f"User '{user}' already has the maximum number of friends ({max_friends})."
+                    )
+
         Friend.objects.create(from_user=self.from_user, to_user=self.to_user)
 
         Friend.objects.create(from_user=self.to_user, to_user=self.from_user)
@@ -169,6 +180,10 @@ class FriendshipManager(models.Manager):
             cache.set(key, friends)
 
         return friends
+
+    def friend_count(self, user):
+        """Return the number of friends ``user`` currently has."""
+        return Friend.objects.filter(to_user=user).count()
 
     def requests(self, user):
         """Return a list of friendship requests"""

--- a/friendship/tests/tests.py
+++ b/friendship/tests/tests.py
@@ -4,10 +4,10 @@ from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
-from friendship.exceptions import AlreadyExistsError, AlreadyFriendsError
+from friendship.exceptions import AlreadyExistsError, AlreadyFriendsError, MaxFriendsExceededError
 from friendship.models import Block, Follow, Friend, FriendshipRequest
 from friendship.signals import (
     block_created,
@@ -785,3 +785,49 @@ class ResubmitAfterRejectionTests(BaseTestCase):
         Friend.objects.add_friend(self.user_bob, self.user_steve).reject()
         req = Friend.objects.add_friend(self.user_steve, self.user_bob)
         self.assertIsNone(req.rejected)
+
+
+class MaxFriendsTests(BaseTestCase):
+    """Optional FRIENDSHIP_MAX_FRIENDS cap enforced at accept time (#82)."""
+
+    def _make_friends(self, user_a, user_b):
+        Friend.objects.add_friend(user_a, user_b).accept()
+
+    def test_friend_count(self):
+        self.assertEqual(Friend.objects.friend_count(self.user_bob), 0)
+        self._make_friends(self.user_bob, self.user_steve)
+        self.assertEqual(Friend.objects.friend_count(self.user_bob), 1)
+
+    def test_unlimited_by_default(self):
+        # No setting configured: behavior is unchanged (backwards compatible).
+        self._make_friends(self.user_bob, self.user_steve)
+        self._make_friends(self.user_bob, self.user_susan)
+        self._make_friends(self.user_bob, self.user_amy)
+        self.assertEqual(Friend.objects.friend_count(self.user_bob), 3)
+
+    @override_settings(FRIENDSHIP_MAX_FRIENDS=2)
+    def test_accept_allowed_under_limit(self):
+        self._make_friends(self.user_bob, self.user_steve)
+        # bob has 1 friend, limit is 2 -> a second acceptance is fine.
+        self._make_friends(self.user_bob, self.user_susan)
+        self.assertEqual(Friend.objects.friend_count(self.user_bob), 2)
+
+    @override_settings(FRIENDSHIP_MAX_FRIENDS=1)
+    def test_accept_blocked_when_requester_at_limit(self):
+        self._make_friends(self.user_bob, self.user_steve)  # bob now has 1 (== limit)
+        req = Friend.objects.add_friend(self.user_bob, self.user_susan)
+        with self.assertRaises(MaxFriendsExceededError):
+            req.accept()
+        # No partial state: no friendship formed, request still pending.
+        self.assertFalse(Friend.objects.are_friends(self.user_bob, self.user_susan))
+        self.assertEqual(Friend.objects.friend_count(self.user_bob), 1)
+        self.assertTrue(Friend.objects.request_exists(self.user_bob, self.user_susan))
+
+    @override_settings(FRIENDSHIP_MAX_FRIENDS=1)
+    def test_accept_blocked_when_addressee_at_limit(self):
+        # susan is at the limit; bob (with room) requesting her still can't be accepted.
+        self._make_friends(self.user_susan, self.user_steve)
+        req = Friend.objects.add_friend(self.user_bob, self.user_susan)
+        with self.assertRaises(MaxFriendsExceededError):
+            req.accept()
+        self.assertFalse(Friend.objects.are_friends(self.user_bob, self.user_susan))


### PR DESCRIPTION
Fixes #82.

## What
Adds an optional `FRIENDSHIP_MAX_FRIENDS` setting that caps how many friends a user may have, enforced when a friendship request is **accepted**.

```python
# settings.py
FRIENDSHIP_MAX_FRIENDS = 800   # unset by default = unlimited
```

When set, `FriendshipRequest.accept()` raises `friendship.exceptions.MaxFriendsExceededError` if **either** user is already at the limit. Also adds a `FriendshipManager.friend_count(user)` helper.

## Backwards compatibility (the focus here)
- **Unset by default → unlimited.** `getattr(settings, "FRIENDSHIP_MAX_FRIENDS", None)`; when `None` the check is skipped entirely, so existing installs behave **identically**. Covered by `test_unlimited_by_default`.
- The new exception is only ever raised when the setting is configured **and** a user is at the cap — never in the default config.
- `friend_count()` is purely additive; no existing method signatures change.
- The check runs **before** any `Friend` rows are created and does **not** delete the request, so a blocked accept leaves no partial state and can be retried after unfriending.
- Setting is namespaced `FRIENDSHIP_MAX_FRIENDS` to match the existing `FRIENDSHIP_CONTEXT_OBJECT_*` settings (rather than the issue's bare `MAX_NUMBER_OF_FRIENDS_ALLOWED`).

## Tests
`MaxFriendsTests`: friend_count, unlimited-by-default (BC), allowed under limit, blocked when requester at limit (with no-partial-state assertions), blocked when addressee at limit. Full suite (43 + 10 subtests) green, lint clean. Changelog `Unreleased` entry added.