### PR TITLE
Resolve users by USERNAME_FIELD in bundled views and templates (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ _Not released yet_
   friends per user, enforced when a request is accepted (raises
   `MaxFriendsExceededError`). Unset by default, so friendships remain unlimited.
   Adds a `FriendshipManager.friend_count(user)` helper (#82)
+- The bundled views and templates now resolve users by the user model's
+  `USERNAME_FIELD` (via `get_username()`) instead of a hardcoded `username`, so
+  they work with custom user models that use a different `USERNAME_FIELD` (e.g.
+  email). No change for the default user model (#57)
 
 ## Version 1.10.0
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,15 @@ except MaxFriendsExceededError:
 Friend.objects.friend_count(request.user)
 ```
 
+### Custom user models
+
+`django-friendship` works with a custom `AUTH_USER_MODEL`. The bundled views and
+templates resolve users by your user model's `USERNAME_FIELD` (via
+`get_username()`), so a model that authenticates by, say, email works out of the
+box — the value captured in the friendship URLs is looked up against
+`USERNAME_FIELD`. For the default user model this is `username`, so nothing
+changes.
+
 ### Contributing
 
 Development [takes place on GitHub](https://github.com/revsys/django-friendship). Bug reports, patches, and fixes are always welcome!

--- a/friendship/templates/friendship/block/add.html
+++ b/friendship/templates/friendship/block/add.html
@@ -1,4 +1,4 @@
-{% if not followee_username == request.user.username %}
+{% if not followee_username == request.user.get_username %}
 {% if errors %}<p>{{ errors|join:", " }}</p>{% endif %}
 <form method="post">
 {% csrf_token %}

--- a/friendship/templates/friendship/follow/add.html
+++ b/friendship/templates/friendship/follow/add.html
@@ -1,4 +1,4 @@
-{% if not followee_username == request.user.username %}
+{% if not followee_username == request.user.get_username %}
 {% if errors %}<p>{{ errors|join:", " }}</p>{% endif %}
 <form method="post">
 {% csrf_token %}

--- a/friendship/templates/friendship/friend/add.html
+++ b/friendship/templates/friendship/friend/add.html
@@ -1,4 +1,4 @@
-{% if not to_username == request.user.username %}
+{% if not to_username == request.user.get_username %}
 {% if errors %}<p>{{ errors|join:", " }}</p>{% endif %}
 <form method="post">
 {% csrf_token %}

--- a/friendship/templates/friendship/header.html
+++ b/friendship/templates/friendship/header.html
@@ -1,3 +1,3 @@
 <div id="link_nav">
-hello {{ user.username }} <a href="{% url 'friendship_requests' %}">friendship requests</a>
+hello {{ user.get_username }} <a href="{% url 'friendship_requests' %}">friendship requests</a>
 </div>

--- a/friendship/templates/friendship/templatetags/blocking.html
+++ b/friendship/templates/friendship/templatetags/blocking.html
@@ -3,7 +3,7 @@
     {% if f.first_name or f.last_name %}
     <li>{{ f.first_name }} {{ f.last_name }}</li>
     {% else %}
-    <li>{{ f.username }}</li>
+    <li>{{ f.get_username }}</li>
     {% endif %}
     {% endfor %}
 </ul>

--- a/friendship/templates/friendship/templatetags/following.html
+++ b/friendship/templates/friendship/templatetags/following.html
@@ -3,7 +3,7 @@
     {% if f.first_name or f.last_name %}
     <li>{{ f.first_name }} {{ f.last_name }}</li>
     {% else %}
-    <li>{{ f.username }}</li>
+    <li>{{ f.get_username }}</li>
     {% endif %}
     {% endfor %}
 </ul>

--- a/friendship/templates/friendship/templatetags/friends.html
+++ b/friendship/templates/friendship/templatetags/friends.html
@@ -1,9 +1,9 @@
 <ul>
 {% for f in friends %}
    {% if f.first_name or f.last_name %}
-   <li>{{ f.username }} ({{ f.first_name }} {{ f.last_name }})</li>
+   <li>{{ f.get_username }} ({{ f.first_name }} {{ f.last_name }})</li>
    {% else %}
-   <li>{{ f.username }}</li>
+   <li>{{ f.get_username }}</li>
    {% endif %}
 {% endfor %}
 </ul>

--- a/friendship/templates/friendship/user_actions.html
+++ b/friendship/templates/friendship/user_actions.html
@@ -2,7 +2,7 @@
 {% for list_user in users %}
     <li>
         {% if user %}
-            {{ list_user.username }} | <a href="{% url 'friendship_add_friend' list_user.username %}">add as friend</a> | <a href="{% url 'follower_add' list_user.username %}">follow user</a>
+            {{ list_user.get_username }} | <a href="{% url 'friendship_add_friend' list_user.get_username %}">add as friend</a> | <a href="{% url 'follower_add' list_user.get_username %}">follow user</a>
         {% endif %}
     </li>
 {% endfor %}

--- a/friendship/tests/tests.py
+++ b/friendship/tests/tests.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 
 from django.contrib.auth.models import User
 from django.core.cache import cache
@@ -831,3 +832,24 @@ class MaxFriendsTests(BaseTestCase):
         with self.assertRaises(MaxFriendsExceededError):
             req.accept()
         self.assertFalse(Friend.objects.are_friends(self.user_bob, self.user_susan))
+
+
+class UsernameFieldTests(BaseTestCase):
+    """Views resolve users by USERNAME_FIELD, not a hardcoded 'username' (#57)."""
+
+    def test_default_username_field_lookup(self):
+        # Backwards compatibility: the default model still resolves by username.
+        url = reverse("friendship_view_friends", kwargs={"username": self.user_steve.username})
+        self.assertResponse200(self.client.get(url))
+
+    def test_lookup_honors_custom_username_field(self):
+        # Pretend the project uses email as USERNAME_FIELD. The view should then
+        # resolve the user by email; under the old hardcoded lookup this 404'd.
+        with mock.patch.object(User, "USERNAME_FIELD", "email"):
+            url = reverse("friendship_view_friends", kwargs={"username": self.user_steve.email})
+            self.assertResponse200(self.client.get(url))
+
+    def test_custom_username_field_unknown_value_404s(self):
+        with mock.patch.object(User, "USERNAME_FIELD", "email"):
+            url = reverse("friendship_view_friends", kwargs={"username": "nobody@example.com"})
+            self.assertResponse404(self.client.get(url))

--- a/friendship/views.py
+++ b/friendship/views.py
@@ -23,9 +23,19 @@ def get_friendship_context_object_list_name():
     return getattr(settings, "FRIENDSHIP_CONTEXT_OBJECT_LIST_NAME", "users")
 
 
+def _username_lookup(value):
+    """Build a lookup dict keyed on the user model's ``USERNAME_FIELD``.
+
+    For the default user model ``USERNAME_FIELD`` is ``"username"``, so this is
+    equivalent to ``{"username": value}`` — behavior is unchanged. Custom user
+    models with a different ``USERNAME_FIELD`` (e.g. email) now work too.
+    """
+    return {user_model.USERNAME_FIELD: value}
+
+
 def view_friends(request, username, template_name="friendship/friend/user_list.html"):
     """View the friends of a user"""
-    user = get_object_or_404(user_model, username=username)
+    user = get_object_or_404(user_model, **_username_lookup(username))
     friends = Friend.objects.friends(user)
     return render(
         request,
@@ -44,7 +54,7 @@ def friendship_add_friend(request, to_username, template_name="friendship/friend
     ctx = {"to_username": to_username}
 
     if request.method == "POST":
-        to_user = user_model.objects.get(username=to_username)
+        to_user = user_model.objects.get(**_username_lookup(to_username))
         from_user = request.user
         try:
             Friend.objects.add_friend(from_user, to_user)
@@ -62,7 +72,7 @@ def friendship_accept(request, friendship_request_id):
     if request.method == "POST":
         f_request = get_object_or_404(request.user.friendship_requests_received, id=friendship_request_id)
         f_request.accept()
-        return redirect("friendship_view_friends", username=request.user.username)
+        return redirect("friendship_view_friends", username=request.user.get_username())
 
     return redirect("friendship_requests_detail", friendship_request_id=friendship_request_id)
 
@@ -118,7 +128,7 @@ def friendship_requests_detail(request, friendship_request_id, template_name="fr
 
 def followers(request, username, template_name="friendship/follow/followers_list.html"):
     """List this user's followers"""
-    user = get_object_or_404(user_model, username=username)
+    user = get_object_or_404(user_model, **_username_lookup(username))
     followers = Follow.objects.followers(user)
     return render(
         request,
@@ -133,7 +143,7 @@ def followers(request, username, template_name="friendship/follow/followers_list
 
 def following(request, username, template_name="friendship/follow/following_list.html"):
     """List who this user follows"""
-    user = get_object_or_404(user_model, username=username)
+    user = get_object_or_404(user_model, **_username_lookup(username))
     following = Follow.objects.following(user)
     return render(
         request,
@@ -152,14 +162,14 @@ def follower_add(request, followee_username, template_name="friendship/follow/ad
     ctx = {"followee_username": followee_username}
 
     if request.method == "POST":
-        followee = user_model.objects.get(username=followee_username)
+        followee = user_model.objects.get(**_username_lookup(followee_username))
         follower = request.user
         try:
             Follow.objects.add_follower(follower, followee)
         except AlreadyExistsError as e:
             ctx["errors"] = [f"{e}"]
         else:
-            return redirect("friendship_following", username=follower.username)
+            return redirect("friendship_following", username=follower.get_username())
 
     return render(request, template_name, ctx)
 
@@ -168,10 +178,10 @@ def follower_add(request, followee_username, template_name="friendship/follow/ad
 def follower_remove(request, followee_username, template_name="friendship/follow/remove.html"):
     """Remove a following relationship"""
     if request.method == "POST":
-        followee = user_model.objects.get(username=followee_username)
+        followee = user_model.objects.get(**_username_lookup(followee_username))
         follower = request.user
         Follow.objects.remove_follower(follower, followee)
-        return redirect("friendship_following", username=follower.username)
+        return redirect("friendship_following", username=follower.get_username())
 
     return render(request, template_name, {"followee_username": followee_username})
 
@@ -184,7 +194,7 @@ def all_users(request, template_name="friendship/user_actions.html"):
 
 def blocking(request, username, template_name="friendship/block/blockers_list.html"):
     """List this user's followers"""
-    user = get_object_or_404(user_model, username=username)
+    user = get_object_or_404(user_model, **_username_lookup(username))
     Block.objects.blocked(user)
 
     return render(
@@ -199,7 +209,7 @@ def blocking(request, username, template_name="friendship/block/blockers_list.ht
 
 def blockers(request, username, template_name="friendship/block/blocking_list.html"):
     """List who this user follows"""
-    user = get_object_or_404(user_model, username=username)
+    user = get_object_or_404(user_model, **_username_lookup(username))
     Block.objects.blocking(user)
 
     return render(
@@ -218,14 +228,14 @@ def block_add(request, blocked_username, template_name="friendship/block/add.htm
     ctx = {"blocked_username": blocked_username}
 
     if request.method == "POST":
-        blocked = user_model.objects.get(username=blocked_username)
+        blocked = user_model.objects.get(**_username_lookup(blocked_username))
         blocker = request.user
         try:
             Block.objects.add_block(blocker, blocked)
         except AlreadyExistsError as e:
             ctx["errors"] = [f"{e}"]
         else:
-            return redirect("friendship_blocking", username=blocker.username)
+            return redirect("friendship_blocking", username=blocker.get_username())
 
     return render(request, template_name, ctx)
 
@@ -234,9 +244,9 @@ def block_add(request, blocked_username, template_name="friendship/block/add.htm
 def block_remove(request, blocked_username, template_name="friendship/block/remove.html"):
     """Remove a following relationship"""
     if request.method == "POST":
-        blocked = user_model.objects.get(username=blocked_username)
+        blocked = user_model.objects.get(**_username_lookup(blocked_username))
         blocker = request.user
         Block.objects.remove_block(blocker, blocked)
-        return redirect("friendship_blocking", username=blocker.username)
+        return redirect("friendship_blocking", username=blocker.get_username())
 
     return render(request, template_name, {"blocked_username": blocked_username})


### PR DESCRIPTION
Fixes #57.

## Problem
The bundled views and templates hardcoded the `username` field — ORM lookups like `user_model.objects.get(username=…)` and attribute reads like `request.user.username`. On a project with a custom `AUTH_USER_MODEL` whose `USERNAME_FIELD` isn't `username` (e.g. email), those raise `FieldError`/`AttributeError`.

## Fix
Resolve users by the model's `USERNAME_FIELD` and read the value via `get_username()`:
- **views.py:** a small `_username_lookup(value)` helper builds `{user_model.USERNAME_FIELD: value}` for all 10 lookups; the 5 redirect reads use `request.user.get_username()` / `follower.get_username()` / `blocker.get_username()`.
- **templates:** `.username` → `.get_username` in the 9 bundled templates.

URL patterns and kwarg names (`username`, `to_username`, …) are unchanged — those are URL parameter names, not model fields.

## Backwards compatibility
For the **default** user model `USERNAME_FIELD == "username"` and `get_username()` returns `.username`, so behavior is **byte-identical** — 10+ years of existing installs are unaffected. No new settings, no signature changes, no URL changes. It's a strict improvement: custom `USERNAME_FIELD` models now work where they previously errored.

## Tests
`UsernameFieldTests`: default lookup still works (BC); with `USERNAME_FIELD` patched to `email`, the view resolves users by email (this 404'd under the old hardcoded lookup); unknown value 404s. Full suite (46 + 10 subtests) green, lint clean.

## Docs
README gains a **Custom user models** section; changelog `Unreleased` entry added.