### PR TITLE
docs: complete and correct the signals reference (docs/signals.rst)

### DIFF
--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -17,7 +17,7 @@ Signals
     ``sender``
         The FriendshipRequest instance that has just been created
 
-* **friendship_request_canceled`**
+* **friendship_request_canceled**
     Sent after FriendshipRequest.cancel deletes the ``sender`` FriendshipRequest object.
 
     ``sender``
@@ -54,26 +54,75 @@ Signals
 
     ``to_user``
 
+.. admonition:: Note
+
+    The follow and block ``*_created`` signals send the **model class** as
+    ``sender`` (``Follow`` or ``Block``), so you can connect a receiver with
+    ``sender=Follow`` / ``sender=Block``. The ``*_removed`` signals send the
+    removed instance.
+
 * **follower_created**
+    Sent by FollowingManager.add_follower.
 
     ``sender``
+        The ``Follow`` model class.
 
     ``follower``
+        The user who is now following someone.
 
-* **following_created**
+* **followee_created**
+    Sent by FollowingManager.add_follower.
 
     ``sender``
+        The ``Follow`` model class.
 
     ``followee``
+        The user who is now being followed.
 
-* **follower_removed**
-
-    ``sender``
-
-    ``follower``
-
-* **following_removed**
+* **following_created**
+    Sent by FollowingManager.add_follower.
 
     ``sender``
+        The ``Follow`` model class.
 
     ``following``
+        The newly created ``Follow`` instance.
+
+* **follower_removed**
+    Sent by FollowingManager.remove_follower.
+
+    ``sender``
+        The removed ``Follow`` instance.
+
+    ``follower``
+        The user who was following.
+
+* **followee_removed**
+    Sent by FollowingManager.remove_follower.
+
+    ``sender``
+        The removed ``Follow`` instance.
+
+    ``followee``
+        The user who was being followed.
+
+* **following_removed**
+    Sent by FollowingManager.remove_follower.
+
+    ``sender``
+        The removed ``Follow`` instance.
+
+    ``following``
+        The removed ``Follow`` instance.
+
+* **block_created**
+    Sent by BlockManager.add_block, once each with ``blocker``, ``blocked``, and ``blocking``.
+
+    ``sender``
+        The ``Block`` model class.
+
+* **block_removed**
+    Sent by BlockManager.remove_block, once each with ``blocker``, ``blocked``, and ``blocking``.
+
+    ``sender``
+        The removed ``Block`` instance.


### PR DESCRIPTION
The Sphinx signals reference was incomplete and had a couple of inaccuracies. Docs-only.

- **Add missing signals:** `followee_created`, `followee_removed`, `block_created`, `block_removed` were emitted by the code but undocumented.
- **Fix argument:** `following_created` sends `following` (the `Follow` instance), not `followee`.
- **Fix typo:** stray backtick on `friendship_request_canceled`.
- **Document `sender` semantics:** the `*_created` follow/block signals send the **model class** as `sender` (so `sender=Follow`/`sender=Block` works — see #89), while `*_removed` send the removed instance.