### PR TITLE
docs: add mkdocstrings API reference and llms.txt landing-page section

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
     python: "3.13"
   jobs:
     install:
-      - pip install zensical
+      - pip install zensical mkdocstrings-python
     build:
       html:
         - zensical build

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,5 +26,35 @@ urlpatterns = [
 ]
 ```
 
-See [Usage](usage.md) for the manager API and template tags, and
-[Signals](signals.md) for the signals the app emits.
+## Where to next
+
+- [Usage](usage.md): the manager API, settings, and template tags
+- [Signals](signals.md): the signals the app emits
+- [API reference](reference.md): the managers, models, and exceptions
+
+## llms.txt
+
+This documentation is available in the [llms.txt](https://llmstxt.org/) format, a
+Markdown convention suited to LLMs and AI coding assistants.
+
+Two files are published:
+
+- [`llms.txt`](https://django-friendship.readthedocs.io/en/latest/llms.txt): a
+  short description of the project plus links to each section of the
+  documentation. The structure is described [here](https://llmstxt.org/#format).
+- [`llms-full.txt`](https://django-friendship.readthedocs.io/en/latest/llms-full.txt):
+  the same index with the content of every page included inline, including the
+  generated API reference.
+
+Every page is also published as Markdown alongside its HTML, so you can link an
+assistant at a single section rather than the whole corpus. Append `.md` to the
+page name:
+
+```text
+https://django-friendship.readthedocs.io/en/latest/usage.md
+https://django-friendship.readthedocs.io/en/latest/signals.md
+https://django-friendship.readthedocs.io/en/latest/reference.md
+```
+
+These files are not picked up automatically by IDEs or coding agents today, but
+most will use them if you supply a link or paste the text.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,31 @@
+# API reference
+
+## Managers
+
+The manager methods are the main entry point — `Friend.objects`, `Follow.objects`,
+and `Block.objects` are instances of these.
+
+::: friendship.models.FriendshipManager
+
+::: friendship.models.FollowingManager
+
+::: friendship.models.BlockManager
+
+## Models
+
+::: friendship.models.FriendshipRequest
+
+::: friendship.models.Friend
+
+::: friendship.models.Follow
+
+::: friendship.models.Block
+
+## Exceptions
+
+::: friendship.exceptions
+    options:
+      members:
+        - AlreadyExistsError
+        - AlreadyFriendsError
+        - MaxFriendsExceededError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ Changelog = "https://github.com/revsys/django-friendship/blob/main/CHANGELOG.md"
 Homepage = "https://github.com/revsys/django-friendship/"
 
 [project.optional-dependencies]
-docs = ["zensical"]
+docs = ["zensical", "mkdocstrings-python"]
 lint = ["prek"]
 test = ["factory-boy", "pytest", "pytest-cov", "pytest-django"]
 testing = ["django-friendship[test]"]

--- a/scripts/gen_llms.py
+++ b/scripts/gen_llms.py
@@ -33,6 +33,7 @@ ORDER = [
     "index",
     "usage",
     "signals",
+    "reference",
 ]
 
 SKIP = {"404"}

--- a/zensical.toml
+++ b/zensical.toml
@@ -15,4 +15,19 @@ nav = [
   { "Overview" = "index.md" },
   { "Usage" = "usage.md" },
   { "Signals" = "signals.md" },
+  { "API reference" = "reference.md" },
 ]
+
+# mkdocstrings analyses the source statically with griffe, so unlike Sphinx
+# autodoc it does not import friendship and needs no django.setup().
+[project.plugins.mkdocstrings.handlers.python]
+paths = ["."]
+inventories = [
+  "https://docs.python.org/3/objects.inv",
+  "https://docs.djangoproject.com/en/stable/_objects/",
+]
+
+[project.plugins.mkdocstrings.handlers.python.options]
+show_source = false
+show_root_heading = true
+members_order = "source"


### PR DESCRIPTION
Follow-up to the zensical migration (#214), bringing the docs to full parity with django-test-plus.

## API reference (exposing the code)
- New `docs/reference.md` documents the managers (`FriendshipManager`, `FollowingManager`, `BlockManager`), models (`FriendshipRequest`, `Friend`, `Follow`, `Block`), and exceptions via mkdocstrings.
- Wire the mkdocstrings Python handler in `zensical.toml` (griffe static analysis — no `django.setup()`), add the page to the nav and to `gen_llms.py`'s `ORDER`, and add `mkdocstrings-python` to the `docs` extra and `.readthedocs.yaml`.

## llms.txt on the landing page
- `docs/index.md` gains a "Where to next" list and an "llms.txt" section explaining the published `llms.txt` / `llms-full.txt` and the `.md`-twin convention — the same details we picked up from django-test-plus.

## Verified locally
`zensical build` renders the API reference (method signatures + docstrings); `gen_llms.py` now emits **4 pages**, and `llms-full.txt` (~1,467 words) folds in the rendered API (e.g. `request_exists`, `friend_count`, `MaxFriendsExceededError`). Lint clean; `site/` stays gitignored.