### PR TITLE
Add Documentation URL to project.urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ content-type = "text/markdown"
 
 [project.urls]
 Changelog = "https://github.com/revsys/django-friendship/blob/main/CHANGELOG.md"
+Documentation = "https://django-friendship.readthedocs.io/"
 Homepage = "https://github.com/revsys/django-friendship/"
 
 [project.optional-dependencies]


### PR DESCRIPTION
Adds a `Documentation` entry to `[project.urls]` pointing at https://django-friendship.readthedocs.io/, so the docs link appears on the PyPI project page (and in `pip show`) once published.

Verified the `Project-URL: Documentation, ...` line is present in the built wheel metadata. Lint clean.