### PR TITLE
docs: rewrite the signals page and add a cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ from friendship.models import Friend, Follow, Block
 
 ### Managing Friendships and Follows
 
+See the [cookbook](https://django-friendship.readthedocs.io/en/latest/cookbook/) for more task-oriented recipes.
+
 #### Create a friendship request:
 
 ```python

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,0 +1,134 @@
+# Cookbook
+
+Task-oriented recipes for common things you'll do with `django-friendship`. Every
+example assumes the models are imported:
+
+```python
+from friendship.models import Block, Follow, Friend, FriendshipRequest
+```
+
+## Send a friend request and handle the outcome
+
+`add_friend` creates a `FriendshipRequest` and returns it. It raises when the
+request can't be made, so handle those cases:
+
+```python
+from django.core.exceptions import ValidationError
+
+from friendship.exceptions import AlreadyExistsError, AlreadyFriendsError
+
+try:
+    request = Friend.objects.add_friend(
+        from_user=request.user,
+        to_user=other_user,
+        message="Hi! I would like to add you",  # optional
+    )
+except ValidationError:
+    ...  # a user cannot friend themselves
+except AlreadyFriendsError:
+    ...  # they are already friends
+except AlreadyExistsError:
+    ...  # a pending request already exists (in either direction)
+```
+
+To check first instead of catching an exception:
+
+```python
+if Friend.objects.request_exists(from_user=request.user, to_user=other_user):
+    ...  # a request is already pending
+```
+
+## Respond to a friend request
+
+```python
+friend_request = FriendshipRequest.objects.get(
+    from_user=other_user, to_user=request.user
+)
+
+friend_request.accept()   # creates the friendship (fires friendship_request_accepted)
+friend_request.reject()   # marks it rejected
+friend_request.cancel()   # the sender withdraws it
+```
+
+A rejected request no longer blocks the future — the sender may
+[`add_friend`](usage.md#managing-friendships) again, and the rejected request is
+revived as a fresh, unread one.
+
+## List friends and pending requests
+
+```python
+# Everyone request.user is friends with
+Friend.objects.friends(user=request.user)
+
+# Requests waiting for request.user to act on
+Friend.objects.unread_requests(user=request.user)
+
+# Requests request.user has sent
+Friend.objects.sent_requests(user=request.user)
+```
+
+## Check whether two users are friends
+
+```python
+if Friend.objects.are_friends(user1=request.user, user2=other_user):
+    ...
+```
+
+## Follow and unfollow
+
+```python
+Follow.objects.add_follower(follower=request.user, followee=other_user)
+Follow.objects.remove_follower(follower=request.user, followee=other_user)
+
+Follow.objects.followers(user=other_user)   # who follows other_user
+Follow.objects.following(user=request.user)  # who request.user follows
+```
+
+## Block and unblock
+
+```python
+Block.objects.add_block(blocker=request.user, blocked=other_user)
+Block.objects.remove_block(blocker=request.user, blocked=other_user)
+
+Block.objects.is_blocked(user1=request.user, user2=other_user)
+```
+
+## Notify a user when they receive a friend request
+
+Use the [`friendship_request_created`](signals.md#friendship_request_created)
+signal so the notification is sent no matter where `add_friend` is called from:
+
+```python
+from django.dispatch import receiver
+
+from friendship.signals import friendship_request_created
+
+
+@receiver(friendship_request_created)
+def email_on_request(sender, **kwargs):
+    friend_request = sender  # the new FriendshipRequest
+    notify(friend_request.to_user, f"{friend_request.from_user} wants to be friends")
+```
+
+See [Signals](signals.md) for every signal and its arguments.
+
+## Cap how many friends a user can have
+
+Set [`FRIENDSHIP_MAX_FRIENDS`](usage.md#settings) and handle the limit when a
+request is accepted:
+
+```python
+from friendship.exceptions import MaxFriendsExceededError
+
+try:
+    friend_request.accept()
+except MaxFriendsExceededError:
+    ...  # this user's friend list is full
+```
+
+## Use a custom user model
+
+Nothing special is required. The bundled views and templates resolve users by
+your model's `USERNAME_FIELD` (via `get_username()`), so a model that
+authenticates by email works out of the box. See
+[Custom user models](usage.md#custom-user-models).

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ urlpatterns = [
 ## Where to next
 
 - [Usage](usage.md): the manager API, settings, and template tags
+- [Cookbook](cookbook.md): task-oriented recipes for common flows
 - [Signals](signals.md): the signals the app emits
 - [API reference](reference.md): the managers, models, and exceptions
 

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,63 +1,21 @@
 # Signals
 
-`django-friendship` emits a number of signals (from `friendship.signals`) after
-various social actions.
+`django-friendship` emits [Django signals](https://docs.djangoproject.com/en/stable/topics/signals/)
+(from `friendship.signals`) after various social actions, so you can react to
+them — send a notification, write an audit log, invalidate a cache — without
+patching the app.
 
 !!! note
 
-    These signals are only emitted when using the manager helper methods. They
-    are **not** emitted if `FriendshipRequest`, `Follow`, or `Block` objects are
-    created manually.
+    Signals are only emitted when you go through the manager helper methods
+    (`add_friend`, `add_follower`, `add_block`, `accept`, …). Creating or deleting
+    `FriendshipRequest`, `Follow`, or `Block` rows directly does **not** fire them.
 
-## Friendship request signals
+## Connecting a receiver
 
-### `friendship_request_created`
-
-Sent whenever `FriendshipManager.add_friend` successfully creates a request.
-
-- `sender` — the `FriendshipRequest` instance that was just created.
-
-### `friendship_request_canceled`
-
-Sent after `FriendshipRequest.cancel` deletes the request.
-
-- `sender` — the `FriendshipRequest` that was canceled by its requester.
-
-### `friendship_request_viewed`
-
-Sent after `FriendshipRequest.mark_viewed` marks the request as viewed.
-
-- `sender` — the `FriendshipRequest` that was viewed.
-
-### `friendship_request_accepted`
-
-Sent after `FriendshipRequest.accept` creates the two `Friend` objects.
-
-- `sender` — the `FriendshipRequest` that was accepted.
-- `from_user` — the request's `from_user`.
-- `to_user` — the request's `to_user`.
-
-### `friendship_request_rejected`
-
-Sent from `FriendshipRequest.reject`.
-
-- `sender` — the rejected `FriendshipRequest`.
-
-### `friendship_removed`
-
-Sent from `FriendshipManager.remove_friend`.
-
-- `sender` — the removed `Friend` instance.
-- `from_user`
-- `to_user`
-
-## Follow and block signals
-
-!!! note
-
-    The `*_created` follow/block signals send the **model class** as `sender`
-    (`Follow` or `Block`), so you can connect a receiver with `sender=Follow` /
-    `sender=Block`. The `*_removed` signals send the removed instance.
+Import the signal and connect a receiver with `@receiver`. Read the values you
+care about from the keyword arguments, and always accept `**kwargs` so your
+receiver keeps working if more arguments are added:
 
 ```python
 from django.dispatch import receiver
@@ -67,62 +25,149 @@ from friendship.signals import follower_created
 
 
 @receiver(follower_created, sender=Follow)
-def on_follow(sender, follower, **kwargs):
+def notify_on_follow(sender, follower, **kwargs):
+    # `follower` is the user who just started following someone.
     ...
 ```
 
+## What `sender` is, and why it matters
+
+`sender` lets you scope a receiver with `@receiver(signal, sender=...)`. In
+`django-friendship` it is not the same kind of object for every signal:
+
+| Signals | `sender` |
+| --- | --- |
+| Follow/block **`*_created`** (`follower_created`, `followee_created`, `following_created`, `block_created`) | the **model class** (`Follow` or `Block`) |
+| Follow/block **`*_removed`** (`follower_removed`, `followee_removed`, `following_removed`, `block_removed`) | the **removed instance** (`Follow` / `Block`) |
+| Friendship-request signals and `friendship_removed` | the relevant **instance** (`FriendshipRequest`, or the removed `Friend`) |
+
+So `@receiver(follower_created, sender=Follow)` works, but connecting to
+`follower_removed` with `sender=Follow` would **not** match — the removed
+signals send an instance, so connect to them without a `sender` and filter
+inside the receiver if you need to.
+
+## Two behaviors worth knowing
+
+!!! warning "`add_follower` emits three _different_ signals"
+
+    A single `Follow.objects.add_follower(...)` call sends `follower_created`,
+    `followee_created`, and `following_created` — once each — carrying the
+    follower, the followee, and the new `Follow` row respectively. Connect to the
+    one that matches what you need.
+
+!!! warning "`block_created` and `block_removed` fire _three times_ per call"
+
+    A single `Block.objects.add_block(...)` sends `block_created` three times:
+    once with `blocker=`, once with `blocked=`, and once with `blocking=` (the
+    `Block` row). Each fire carries only **one** of those keys, so a receiver on
+    `block_created` runs three times per block. Guard for the key you want:
+
+    ```python
+    from friendship.models import Block
+    from friendship.signals import block_created
+
+
+    @receiver(block_created, sender=Block)
+    def on_block(sender, **kwargs):
+        if "blocking" in kwargs:  # the Block row; fires once per add_block
+            block = kwargs["blocking"]
+            ...
+    ```
+
+## Friendship request signals
+
+### `friendship_request_created`
+
+Sent when `Friend.objects.add_friend(...)` successfully creates a request.
+
+- `sender` — the newly created `FriendshipRequest`.
+
+### `friendship_request_accepted`
+
+Sent when `FriendshipRequest.accept()` creates the two `Friend` rows.
+
+- `sender` — the accepted `FriendshipRequest`.
+- `from_user` — the user who sent the request.
+- `to_user` — the user who accepted it.
+
+### `friendship_request_rejected`
+
+Sent from `FriendshipRequest.reject()`.
+
+- `sender` — the rejected `FriendshipRequest`.
+
+### `friendship_request_canceled`
+
+Sent after `FriendshipRequest.cancel()` deletes the request.
+
+- `sender` — the `FriendshipRequest` that was canceled by its sender.
+
+### `friendship_request_viewed`
+
+Sent after `FriendshipRequest.mark_viewed()` marks the request as viewed.
+
+- `sender` — the viewed `FriendshipRequest`.
+
+### `friendship_removed`
+
+Sent from `Friend.objects.remove_friend(...)`.
+
+- `sender` — the removed `Friend` instance.
+- `from_user` — one side of the friendship.
+- `to_user` — the other side.
+
+## Follow signals
+
+Sent by `Follow.objects.add_follower(...)` (created) and
+`Follow.objects.remove_follower(...)` (removed). The `*_created` signals send
+`Follow` (the class) as `sender`; the `*_removed` signals send the removed row.
+
 ### `follower_created`
 
-Sent by `FollowingManager.add_follower`.
-
-- `sender` — the `Follow` model class.
+- `sender` — the `Follow` class.
 - `follower` — the user who is now following someone.
 
 ### `followee_created`
 
-Sent by `FollowingManager.add_follower`.
-
-- `sender` — the `Follow` model class.
+- `sender` — the `Follow` class.
 - `followee` — the user who is now being followed.
 
 ### `following_created`
 
-Sent by `FollowingManager.add_follower`.
-
-- `sender` — the `Follow` model class.
-- `following` — the newly created `Follow` instance.
+- `sender` — the `Follow` class.
+- `following` — the newly created `Follow` row.
 
 ### `follower_removed`
 
-Sent by `FollowingManager.remove_follower`.
-
-- `sender` — the removed `Follow` instance.
+- `sender` — the removed `Follow` row.
 - `follower` — the user who was following.
 
 ### `followee_removed`
 
-Sent by `FollowingManager.remove_follower`.
-
-- `sender` — the removed `Follow` instance.
+- `sender` — the removed `Follow` row.
 - `followee` — the user who was being followed.
 
 ### `following_removed`
 
-Sent by `FollowingManager.remove_follower`.
+- `sender` — the removed `Follow` row.
+- `following` — the removed `Follow` row.
 
-- `sender` — the removed `Follow` instance.
-- `following` — the removed `Follow` instance.
+## Block signals
+
+Both fire **three times** per call (see [above](#two-behaviors-worth-knowing)),
+once each with `blocker`, `blocked`, and `blocking`.
 
 ### `block_created`
 
-Sent by `BlockManager.add_block`, once each with `blocker`, `blocked`, and
-`blocking`.
+Sent by `Block.objects.add_block(...)`.
 
-- `sender` — the `Block` model class.
+- `sender` — the `Block` class.
+- one of `blocker` (the user doing the blocking), `blocked` (the user being
+  blocked), or `blocking` (the new `Block` row).
 
 ### `block_removed`
 
-Sent by `BlockManager.remove_block`, once each with `blocker`, `blocked`, and
-`blocking`.
+Sent by `Block.objects.remove_block(...)`.
 
-- `sender` — the removed `Block` instance.
+- `sender` — the removed `Block` row.
+- one of `blocker`, `blocked`, or `blocking` (the removed `Block` row).

--- a/scripts/gen_llms.py
+++ b/scripts/gen_llms.py
@@ -32,6 +32,7 @@ SUMMARY = "Create and manage follows, blocks, and bi-directional friendships bet
 ORDER = [
     "index",
     "usage",
+    "cookbook",
     "signals",
     "reference",
 ]

--- a/zensical.toml
+++ b/zensical.toml
@@ -14,6 +14,7 @@ edit_uri = "edit/main/docs/"
 nav = [
   { "Overview" = "index.md" },
   { "Usage" = "usage.md" },
+  { "Cookbook" = "cookbook.md" },
   { "Signals" = "signals.md" },
   { "API reference" = "reference.md" },
 ]


### PR DESCRIPTION
A pass over the docs to make the harder-to-grok parts clear, and to expand the recipe-style content the README only hinted at.

## Signals page, spelled out
Rewrote `docs/signals.md` so a reader actually understands the signals:
- **How to connect a receiver** (with `**kwargs`, using keyword-style access).
- **What `sender` is per signal**, in a table — the follow/block `*_created` signals send the **model class** (so `sender=Follow`/`sender=Block` works), while `*_removed` and the request signals send an **instance**.
- Two **`!!! warning` callouts** for the surprising behavior:
  - `add_follower` emits **three different** signals (`follower_created`, `followee_created`, `following_created`).
  - `block_created` / `block_removed` each **fire three times** per call (once with `blocker`, `blocked`, `blocking`), with a guard example.
- Per-signal reference with exact arguments, verified against the source.

## New cookbook page
`docs/cookbook.md` — task-oriented recipes: send a request and handle `AlreadyExistsError`/`AlreadyFriendsError`/`ValidationError`; accept/reject/cancel; list friends & requests; follow/unfollow; block/unblock; notify via the `friendship_request_created` signal; cap friends with `FRIENDSHIP_MAX_FRIENDS`; custom user models. Wired into the nav, the `gen_llms.py` ORDER (now 5 pages / ~2.2k words in `llms-full.txt`), and linked from the README.

All examples use **keyword arguments**. `zensical build` is clean and lint passes.