### PR TITLE
Bump ruff-pre-commit to v0.16.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         alias: autoformat
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.0
+    rev: v0.16.1
     hooks:
       - id: ruff-check
         args: [--fix]


### PR DESCRIPTION
Bumps the pinned `ruff-pre-commit` hook from v0.16.0 to v0.16.1. No files were reformatted by the new ruff version; all hooks pass clean.